### PR TITLE
Use default window background on fullscreen (fix #28)

### DIFF
--- a/CEDocument.m
+++ b/CEDocument.m
@@ -967,7 +967,7 @@ enum { typeFSS = 'fss ' };
         [[_windowController window] setAlphaValue:1.0];
         [[_editorView splitView] setAllBackgroundColorWithAlpha:theAlpha];
     } else {
-        [[_windowController window] setBackgroundColor:[NSColor windowBackgroundColor]]; // 通常の背景色をセット
+        [[_windowController window] setBackgroundColor:nil]; // 通常の背景色をセット
         [[_windowController window] setOpaque:YES]; // ウィンドウを不透明にする
         [[_windowController window] setAlphaValue:theAlpha];
         [[_editorView splitView] setAllBackgroundColorWithAlpha:1.0];

--- a/CEWindowController.m
+++ b/CEWindowController.m
@@ -448,6 +448,28 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 }
 
 
+// ------------------------------------------------------
+- (void)windowWillEnterFullScreen:(NSNotification *)notification
+// フルスクリーンを開始
+// ------------------------------------------------------
+{
+    // ウインドウ背景をデフォルトにする（ツールバーの背景に影響）
+    [[self window] setBackgroundColor:nil];
+}
+
+
+// ------------------------------------------------------
+- (void)windowDidExitFullScreen:(NSNotification *)notification
+// フルスクリーンを終了
+// ------------------------------------------------------
+{
+    // ウインドウ背景を戻す
+    if ([[self document] alphaOnlyTextViewInThisWindow]) {
+        [[self window] setBackgroundColor:[NSColor clearColor]];
+    }
+}
+
+
 
 #pragma mark ===== Action messages =====
 


### PR DESCRIPTION
issue #28 の修正です。

フルスクリーンの際のツールバー部分の色はwindowそのもののbackgroundの色のようです。とはいえ透明背景色はテキストビューの半透明化には外せないので、フルスクリーンのときのみデフォルトの背景色を使うようにしました（`nil` を送るとデフォルトになるようです）。
