### PR TITLE
Resolve Xcode warning about RegexKitLite

### DIFF
--- a/ImportSources/RegexKitLite.m
+++ b/ImportSources/RegexKitLite.m
@@ -1196,7 +1196,7 @@ static void rkl_handleDelayedAssert(id self, SEL _cmd, id exception) {
     else {
       id functionString = [exception objectForKey:@"function"], fileString = [exception objectForKey:@"file"], descriptionString = [exception objectForKey:@"description"], lineNumber = [exception objectForKey:@"line"];
       RKLCHardAbortAssert((functionString != NULL) && (fileString != NULL) && (descriptionString != NULL) && (lineNumber != NULL));
-      [[NSAssertionHandler currentHandler] handleFailureInFunction:functionString file:fileString lineNumber:(NSInteger)[lineNumber longValue] description:descriptionString];
+      [[NSAssertionHandler currentHandler] handleFailureInFunction:functionString file:fileString lineNumber:(NSInteger)[lineNumber longValue] description:@"%@", descriptionString];
     }
   }
 }


### PR DESCRIPTION
気になるので、RegexKitLiteに出てるwarningを潰しました。
[本家への報告](http://sourceforge.net/p/regexkit/bugs/66/) にfix案が出ていて、それで問題なさそうなのでその1行に入れ替えただけです。
