### PR TITLE
Fixed the file size update issue on file save

### DIFF
--- a/CotEditor/Sources/CEWindowController.m
+++ b/CotEditor/Sources/CEWindowController.m
@@ -168,7 +168,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     NSString *finderLockInfo = [fileAttributes fileIsImmutable] ? NSLocalizedString(@"ON", nil) : nil;
     [self setFinderLockInfo:finderLockInfo];
     [self setPermissionInfo:[NSString stringWithFormat:@"%tu", [fileAttributes filePosixPermissions]]];
+    NSNumber *beforeFileSize = [self fileSizeInfo];
     [self setFileSizeInfo:@([fileAttributes fileSize])];
+    if (![beforeFileSize isEqualToNumber:[self fileSizeInfo]]) {
+        [[self editorView] updateLineEndingsInStatusAndInfo:false];
+    }
 }
 
 


### PR DESCRIPTION
There was a bug where the file size display on status bar was not
updated when a file was saved. The users had to re-open the document in
order to update the file size display.

This patch fixes the issue by forcing status bar right text field to
update when a file size is updated. The performance impact of this
patch should be minimal.
