### PR TITLE
Fix/issue193 invisibles fallback

### DIFF
--- a/CotEditor/Sources/CELayoutManager.m
+++ b/CotEditor/Sources/CELayoutManager.m
@@ -194,10 +194,10 @@
         CGContextConcatCTM(context, transform);
         
         // prepare glyphs
-        CGPathRef spaceGlyphPath = [self glyphPathWithCharacter:[self spaceChar] font:font];
-        CGPathRef tabGlyphPath = [self glyphPathWithCharacter:[self tabChar] font:font];
-        CGPathRef newLineGlyphPath = [self glyphPathWithCharacter:[self newLineChar] font:font];
-        CGPathRef fullWidthSpaceGlyphPath = [self glyphPathWithCharacter:[self fullwidthSpaceChar] font:font];
+        CGPathRef spaceGlyphPath = glyphPathWithCharacter([self spaceChar], font);
+        CGPathRef tabGlyphPath = glyphPathWithCharacter([self tabChar], font);
+        CGPathRef newLineGlyphPath = glyphPathWithCharacter([self newLineChar], font);
+        CGPathRef fullWidthSpaceGlyphPath = glyphPathWithCharacter([self fullwidthSpaceChar], font);
         
         // store value to avoid accessing properties each time  (2014-07 by 1024jp)
         BOOL showsSpace = [self showsSpace];
@@ -212,22 +212,22 @@
             unichar character = [completeStr characterAtIndex:charIndex];
 
             if (showsSpace && ((character == ' ') || (character == 0x00A0))) {
-                CGPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
+                NSPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
                 CGAffineTransform translate = CGAffineTransformMakeTranslation(point.x, point.y);
                 CGPathAddPath(paths, &translate, spaceGlyphPath);
 
             } else if (showsTab && (character == '\t')) {
-                CGPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
+                NSPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
                 CGAffineTransform translate = CGAffineTransformMakeTranslation(point.x, point.y);
                 CGPathAddPath(paths, &translate, tabGlyphPath);
                 
             } else if (showsNewLine && (character == '\n')) {
-                CGPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
+                NSPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
                 CGAffineTransform translate = CGAffineTransformMakeTranslation(point.x, point.y);
                 CGPathAddPath(paths, &translate, newLineGlyphPath);
 
             } else if (showsFullwidthSpace && (character == 0x3000)) { // Fullwidth-space (JP)
-                CGPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
+                NSPoint point = [self pointToDrawGlyphAtIndex:glyphIndex];
                 CGAffineTransform translate = CGAffineTransformMakeTranslation(point.x, point.y);
                 CGPathAddPath(paths, &translate, fullWidthSpaceGlyphPath);
 
@@ -259,6 +259,11 @@
         
         // release
         CGContextRestoreGState(context);
+        CGPathRelease(paths);
+        CGPathRelease(spaceGlyphPath);
+        CGPathRelease(tabGlyphPath);
+        CGPathRelease(newLineGlyphPath);
+        CGPathRelease(fullWidthSpaceGlyphPath);
     }
     
     [super drawGlyphsForGlyphRange:glyphsToShow atPoint:origin];
@@ -358,27 +363,44 @@
 
 //------------------------------------------------------
 /// グリフを描画する位置を返す
-- (CGPoint)pointToDrawGlyphAtIndex:(NSUInteger)glyphIndex
+- (NSPoint)pointToDrawGlyphAtIndex:(NSUInteger)glyphIndex
 //------------------------------------------------------
 {
     NSPoint drawPoint = [self locationForGlyphAtIndex:glyphIndex];
     NSPoint glyphPoint = [self lineFragmentRectForGlyphAtIndex:glyphIndex effectiveRange:NULL].origin;
     
-    return CGPointMake(drawPoint.x, -glyphPoint.y);
+    return NSMakePoint(drawPoint.x, -glyphPoint.y);
 }
 
 
 
 //------------------------------------------------------
 /// 文字とフォントからアウトラインパスを生成して返す
-- (CGPathRef)glyphPathWithCharacter:(unichar)character font:(CTFontRef)font
+CGPathRef glyphPathWithCharacter(unichar character, CTFontRef font)
 //------------------------------------------------------
 {
+    CGFloat fontSize = CTFontGetSize(font);
     CGGlyph glyph;
     
-    CTFontGetGlyphsForCharacters(font, &character, &glyph, 1);
+    if (CTFontGetGlyphsForCharacters(font, &character, &glyph, 1)) {
+        return CTFontCreatePathForGlyph(font, glyph, NULL);
+    }
     
-    return CTFontCreatePathForGlyph(font, glyph, NULL);
+    // try fallback fonts in cases where user font doesn't support the input charactor
+    // - All invisible characters of choices can be covered with the following two fonts.
+    CGPathRef path = NULL;
+    NSArray *fallbackFontNames = @[@"LucidaGrande", @"HiraKakuProN-W3"];
+    
+    for (NSString *fontName in fallbackFontNames) {
+        CTFontRef fallbackFont = CTFontCreateWithName((CFStringRef)fontName, fontSize, 0);
+        if (CTFontGetGlyphsForCharacters(fallbackFont, &character, &glyph, 1)) {
+            path = CTFontCreatePathForGlyph(fallbackFont, glyph, NULL);
+            break;
+        }
+        CFRelease(fallbackFont);
+    }
+    
+    return path;
 }
 
 @end


### PR DESCRIPTION
#193 の修正です。
#### #193の問題点
#175 の不可視文字描画方法はコンテクストで設定したフォント内のグリフを指定して描画するので、ユーザの指定したフォントが該当グリフを持っていなかったときに豆腐が表示されてしまう。
#### 解決法

CGGlyphを直接描画させるのではなく、先にグリフからアウトラインパスを抽出しそれをコンテクストに描画させる。これにより複数フォントが混在した描画が可能となる。ユーザ指定のフォントが当該グリフを持っていなかった場合は、CotEditorであらかじめ準備しておいたフォント（Lucida Grandeとヒラギノ角ゴシックProN W3）からアウトラインを生成する。
#### 副作用
- #175 に比べると若干パフォーマンスが落ちる（が CotEditor 1.5.4 から比べれば依然として圧倒的に高い）
- プリントパネルからPDFを生成した際に、不可視文字のデータが文字データではなくアウトラインとなってしまう（逆に文字として選択できないから良いという考え方もある）
#### ディスカッション

正直なところ本当は不可視文字を描画するフォントはユーザの指定したテキスト用のフォントとは別で固定してしまいたい。
1. CGGlyph で描画する方がロジックとしてはシンプルでパフォーマンスも高い
2. フォントによっては環境設定でのポップアップの表示とは見た目が大きく異なり、期待した出力が得られない。
   - もっと言うと、テキスト用フォントとしてMenloを指定しているのだが、等幅フォントなこともあり不可視文字が小さくて見づらい（これは #193 の問題とは別件）

しかし、OS X バンドルの標準的なフォントには CotEditor で選べる不可視文字用文字を全て収まりよく描画できるフォントが存在しない。以下は、代表的なフォントの対応状況である（グレーアウトしているものは非対応）。

![screen shot 2014-08-02 at 18 44 37](https://cloud.githubusercontent.com/assets/1165044/3788400/96d91b56-1a64-11e4-848b-a165a9f83b3f.png)

強いて挙げればMenloは全て対応しているが先に挙げたとおり小さいので不可視文字描画としてはふさわしくない。

それをふまえて以下は提案です（現時点では修正には含まれていません。
##### 提案1

不可視文字描画のフォントをLucida Grande（ない場合はヒラギノ角ゴ）に固定する。描画方法は依然としてアウトラインパスから行なうことになるが、ユーザのフォントに関わらず環境設定のポップアップと同等の画が得られるようになる。懸念としては、Lucida Grande の四角類はサイズが小さいので全角空白の代替表示としては少し不格好かもしれない（白抜きの四角に関してはわざとLucida Grande が所持しておらずヒラギノだけが表示できる文字（▢）に変更することによって、ヒラギノでの描画を強制することもできそう）。
##### 提案2

提案1にくわえ、CotEditorの不可視文字代替文字の選択肢から「⏎」（白抜き矢印）と「⊠」（四角にバツ）をドロップすると、Lucida Grande で全ての描画が可能となる。しかし、「⏎」は将にリターンを表す文字なので失くすには少し惜しい気もする。

提案2は本末転倒かもしれませんが、とくに提案1に関していかがでしょうか？
