### PR TITLE
Update appcast creation script for sandboxed version (#406)

### DIFF
--- a/release/2_create_appcast.rb
+++ b/release/2_create_appcast.rb
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+IS_SANDBOXED = true
+APPCAST_PATH = "./appcast.xml"
+
 app = "./CotEditor.app"
 
 unless Dir.exist?(app) then
@@ -17,10 +20,9 @@ unless File.exist?(dmg) then
 	exit
 end
 
-appcast = "./appcast.xml"
 
-if File.exist?(appcast) then
-	puts "Already exist : #{appcast}"
+if File.exist?(APPCAST_PATH) then
+	puts "Already exist : #{APPCAST_PATH}"
 	exit
 end
 
@@ -39,15 +41,23 @@ require 'time'
 date = File.mtime(dmg).rfc822
 length = File.size(dmg)
 
-# Output appcast
-open(appcast, "w") { |file|
-file.puts <<APPCAST
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
-	<channel>
-		<title>CotEditor update information</title>
-		<link>http://coteditor.com/releasenotes/appcast.xml</link>
-		<description>CotEditor update information</description>
+
+# craate last item code
+if IS_SANDBOXED then
+	latest_item = <<-APPCAST_ITEM
+		<item>
+			<title>CotEditor #{version}</title>
+			<sparkle:releaseNotesLink xml:lang="en">http://coteditor.com/releasenotes/#{version}.en.html</sparkle:releaseNotesLink>
+			<sparkle:releaseNotesLink xml:lang="ja">http://coteditor.com/releasenotes/#{version}.ja.html</sparkle:releaseNotesLink>
+			<pubDate>#{date}</pubDate>
+			<sparkle:minimumSystemVersion>10.8</sparkle:minimumSystemVersion>
+			<sparkle:version>#{version}</sparkle:version>
+            <link>http://coteditor.com/</link>
+		</item>
+	APPCAST_ITEM
+else
+	# normal appcast
+	latest_item = <<-APPCAST_ITEM
 		<item>
 			<title>CotEditor #{version}</title>
 			<sparkle:releaseNotesLink xml:lang="en">http://coteditor.com/releasenotes/#{version}.en.html</sparkle:releaseNotesLink>
@@ -58,8 +68,22 @@ file.puts <<APPCAST
 			           sparkle:version="#{version}"
 			           sparkle:dsaSignature="#{dsa}"
 			           length="#{length}"
-			           type="application/octet-stream" />
+			           type="application/octet-stream"/>
 		</item>
+	APPCAST_ITEM
+end
+
+
+# Output appcast
+open(APPCAST_PATH, "w") { |file|
+file.puts <<APPCAST
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+	<channel>
+		<title>CotEditor update information</title>
+		<link>http://coteditor.com/releasenotes/appcast.xml</link>
+		<description>CotEditor update information</description>
+#{latest_item}
 		<item>
 			<title>CotEditor 2.0.3</title>
 			<sparkle:releaseNotesLink xml:lang="en">http://coteditor.com/releasenotes/2.0.3.en.html</sparkle:releaseNotesLink>
@@ -70,7 +94,7 @@ file.puts <<APPCAST
 			           sparkle:version="2.0.3"
 			           sparkle:dsaSignature="MC0CFQC/u3nS+yqNHrr1+EghgQksnBlF2AIUfJ5SyL10uO1jSK01ZQgXM3xBE5s="
 			           length="14414610"
-			           type="application/octet-stream" />
+			           type="application/octet-stream"/>
 		</item>
 	</channel>
 </rss>


### PR DESCRIPTION
appcast を生成するスクリプトを改変したのですが、どうも Ruby が苦手なので @usami-k さんにレビューをしていただいてからマージしていただきたいと考えています。

やったこと:
- appcast の `item` 要素を生成する部分を抜きだし、
    - Sandbox 化されたアプリケーション（今後 2.2.0-beta 以降使用する）
    -  Sandbox 化されていないアプリケーション（従来のコードのまま。Sparkle が Sandbox 環境下でインストールが行えるようになったらこれに戻す）

    の2パターンで生成するコードを切り替えるようにした
    この2つはスクリプト冒頭で定義される `IS_SANDBOXED` 定数フラグで切り替えられる
- Sandbox 化されたアプリケーションでは、ダウンロードする dmg を提供せず、バージョンとダウンロードページの URL のみを提供する。これにより「Install」ボタンが「Learn More...」ボタンに変化する [画像参照]。この仕様については以下の stackoverflow の説明を参考としている。

![screen shot 2015-08-15 at 05 10 17](https://cloud.githubusercontent.com/assets/1165044/9283094/05d8d7f0-430c-11e5-9cdf-f3f4705e2ae6.png)


補足: 
Issue #406 で「βリリース用に appcast 生成スクリプトを改変する必要がある」と書いたのですが、考えてみたら、appcast.xml と appcast-beta.xml はファイルを更新するタイミングが違うだけで生成される内容のロジックに変わりはないと思うので、これで appcast.xml 用の改変は終わりなのではないかと思います。

-- 

Since the current Sparkle (1.10) cannot update Sandboxed application, we disable installation via Sparkle. The new appcast just show a release note and provide a button to jump to a webpage. You can toggle this behavior changing `is_sandboxed` variable.

cf. http://stackoverflow.com/questions/15170417/