### PR TITLE
Avoid checking beta with Sparkle by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 Change Log
 ==========================
 
+develop
+--------------------------
+
+### Additions/Changes
+
+- [beta][non-AppStore ver.] Change to not check pre-release versions on default.
+
+
+
 2.2.0-beta
 --------------------------
 

--- a/CotEditor/CotEditor.xcodeproj/project.pbxproj
+++ b/CotEditor/CotEditor.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		2A009ACB1A57BA8B00C3D542 /* CETextFinder.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A009ACA1A57BA8B00C3D542 /* CETextFinder.m */; };
 		2A009AD11A58ED1D00C3D542 /* CEFindResultViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A009AD01A58ED1D00C3D542 /* CEFindResultViewController.m */; };
 		2A009ADA1A5AAE8000C3D542 /* CEFindPanelSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A009AD91A5AAE8000C3D542 /* CEFindPanelSplitView.m */; };
+		2A0678DD1B86A4A20095BD2E /* CEDocument+Authopen.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A77C9341B416C950033D4AB /* CEDocument+Authopen.m */; };
 		2A07202B18E0E1C2006F3A43 /* CEPrintPanelAccessoryController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A07202A18E0E1C2006F3A43 /* CEPrintPanelAccessoryController.m */; };
 		2A07202E18E0E421006F3A43 /* PrintPanelAccessory.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2A07202C18E0E421006F3A43 /* PrintPanelAccessory.xib */; };
 		2A1068C31A745FCE001DB9AA /* NSURL+Xattr.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A1068C21A745FCE001DB9AA /* NSURL+Xattr.m */; };
@@ -1868,6 +1869,7 @@
 				2A7846DE18FE0C0C006BDF00 /* CETheme.m in Sources */,
 				2A68F93818FB04F400673440 /* CEMenuItemCell.m in Sources */,
 				2AB432711912AF7200835004 /* CEGlyphPopoverController.m in Sources */,
+				2A0678DD1B86A4A20095BD2E /* CEDocument+Authopen.m in Sources */,
 				2AE356461A86D32500E29FEF /* CEClipView.m in Sources */,
 				2AFFB71B18D7F18300118477 /* CEGoToSheetController.m in Sources */,
 				2A3FB2AD18ECEFF200D9CB2C /* CESyntaxEditSheetController.m in Sources */,

--- a/CotEditor/Sources/CEAppDelegate.m
+++ b/CotEditor/Sources/CEAppDelegate.m
@@ -97,7 +97,7 @@
     }
     
     NSDictionary *defaults = @{CEDefaultDocumentConflictOptionKey: @(CEDocumentConflictRevert),
-                               CEDefaultChecksUpdatesForBetaKey: @YES,
+                               CEDefaultChecksUpdatesForBetaKey: @NO,
                                CEDefaultLayoutTextVerticalKey: @NO,
                                CEDefaultSplitViewVerticalKey: @NO,
                                CEDefaultShowLineNumbersKey: @YES,


### PR DESCRIPTION
現在デフォルトでプレリリース版が更新対象となっているが、それをオフにする。
`NSUserDefaults` の特性上、デフォルトと同じ値の時は、ユーザ設定に具体的な値は設定されず空欄となる。
つまり、このままだと、β版を使用している時にプレリリースをチェックする設定に意図的にしたユーザも、安定版で設定がデフォルトで `@NO` になると、勝手に `@NO` に切り替わってしまう。

基本的にプレリリース版へのアップデートは、ユーザが明示的に決められるようにしたいので、
デフォルト値は一貫して `@NO` にしようと思います。
ただ、β 使用中は速やかに新しいバージョンに変更してほしいので、β 中は何らか別の方法で（自動更新をONにしている場合は）強制的に新しいβが出たら通知を出すようにするという手もあります。技術的には簡単に実装できるはずです（この件については現時点で本 pull-request に含まれていません）

妥当なようであればマージお願いします。