### PR TITLE
Change versioning system

### DIFF
--- a/CotEditor/CotEditor (AppStore)-Info.plist
+++ b/CotEditor/CotEditor (AppStore)-Info.plist
@@ -957,7 +957,7 @@
 	<key>CFBundleSignature</key>
 	<string>cEd1</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.0-beta</string>
+	<string>63</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>NSAppleScriptEnabled</key>

--- a/CotEditor/CotEditor-Info.plist
+++ b/CotEditor/CotEditor-Info.plist
@@ -957,7 +957,7 @@
 	<key>CFBundleSignature</key>
 	<string>cEd1</string>
 	<key>CFBundleVersion</key>
-	<string>2.2.0-beta</string>
+	<string>63</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>NSAppleScriptEnabled</key>

--- a/CotEditor/Sources/CEAppDelegate.m
+++ b/CotEditor/Sources/CEAppDelegate.m
@@ -42,7 +42,6 @@
 #import "CEUnicodeInputPanelController.h"
 #import "CEMigrationWindowController.h"
 #import "CEDocument.h"
-#import "EDSemver.h"
 #import "Constants.h"
 
 #ifndef APPSTORE
@@ -376,11 +375,13 @@
     [self migrateIfNeeded];
     
     // store latest version
+    //     The bundle version (build number) format was changed on CotEditor 2.2.0. due to the iTunes Connect versioning rule.
+    //      < 2.2.0 : The Semantic Versioning
+    //     >= 2.2.0 : Single Integer
     NSString *lastVersion = [[NSUserDefaults standardUserDefaults] stringForKey:CEDefaultLastVersionKey];
     NSString *thisVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
-    EDSemver *lastSemver = lastVersion ? [EDSemver semverWithString:lastVersion] : nil;
-    EDSemver *thisSemver = [EDSemver semverWithString:thisVersion];
-    if (!lastSemver || [lastSemver isLessThan:thisSemver]) {
+    BOOL isDigit = lastVersion && [lastVersion rangeOfString:@"^[\\d]+$" options:NSRegularExpressionSearch].location != NSNotFound;
+    if (isDigit && [thisVersion integerValue] > [lastVersion integerValue]) {
         [[NSUserDefaults standardUserDefaults] setObject:thisVersion forKey:CEDefaultLastVersionKey];
     }
     

--- a/CotEditor/en.lproj/Acknowledgements.rtf
+++ b/CotEditor/en.lproj/Acknowledgements.rtf
@@ -122,8 +122,7 @@ SUCH DAMAGE.\
 \b0   ({\field{\*\fldinst{HYPERLINK "http://sparkle-project.org"}}{\fldrslt http://sparkle-project.org}})\
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\sl264\slmult1
 \cf0 Thanks to Sparkle, the software update framework, by Andy Matuschak et al.  Sparkle is distributed under the MIT license, as specified below.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\sl264\slmult1
-\cf0 \CocoaLigature0 \
+\CocoaLigature0 \
 \pard\tx529\pardeftab529\sl264\slmult1\pardirnatural
 
 \fs22 \cf3 \'a9 2006-2013 Andy Matuschak\
@@ -212,39 +211,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\
 SOFTWARE.
 \fs24 \cf0 \CocoaLigature1 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-\cf0 \
-\
-\pard\tx565\tx1133\tx1700\tx2266\tx2832\tx3401\tx3967\tx4535\tx5102\tx5669\tx6235\tx6802\pardeftab529\sl264\slmult1
-
-\b \cf0 EDSemVer
-\b0   ({\field{\*\fldinst{HYPERLINK "https://github.com/thisandagain/semver"}}{\fldrslt https://github.com/thisandagain/semver}})\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-\cf0 Thanks to EDSemVer, the semantic versioning parser, by Andrew Sliwinski.  EDSemVer is distributed under the MIT license, as specified below.\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-
-\fs22 \cf3 \
-\pard\tx565\tx1133\tx1700\tx2266\tx2832\tx3401\tx3967\tx4535\tx5102\tx5669\tx6235\tx6802\pardeftab529\sl264\slmult1
-\cf3 Copyright (c) 2013 Andrew Sliwinski\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy\
-of this software and associated documentation files (the "Software"), to deal\
-in the Software without restriction, including without limitation the rights\
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
-copies of the Software, and to permit persons to whom the Software is\
-furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in\
-all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\
-THE SOFTWARE.
-\fs24 \cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
 \cf0 \
 \

--- a/CotEditor/ja.lproj/Acknowledgements.rtf
+++ b/CotEditor/ja.lproj/Acknowledgements.rtf
@@ -238,49 +238,10 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\
-SOFTWARE.
-\fs24 \cf0 \CocoaLigature1 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-\cf0 \
-\
-\pard\tx565\tx1133\tx1700\tx2266\tx2832\tx3401\tx3967\tx4535\tx5102\tx5669\tx6235\tx6802\pardeftab529\sl264\slmult1
-
-\b \cf0 EDSemVer
-\b0   ({\field{\*\fldinst{HYPERLINK "https://github.com/thisandagain/semver"}}{\fldrslt https://github.com/thisandagain/semver}})\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-\cf0 Semantic Versioning 
-\f0 \'82\'cc\'83\'70\'81\'5b\'83\'54\'82\'c6\'82\'b5\'82\'c4 
-\f1 EDSemVer
-\f0  (written by Andrew Sliwinski) \'82\'f0\'8e\'67\'97\'70\'82\'b3\'82\'b9\'82\'c4\'92\'b8\'82\'ab\'82\'dc\'82\'b5\'82\'bd\'81\'42
-\f1 EDSemVer
-\f0  \'82\'cd MIT \'83\'89\'83\'43\'83\'5a\'83\'93\'83\'58\'82\'c5\'94\'7a\'95\'74\'82\'b3\'82\'ea\'82\'c4\'82\'a2\'82\'dc\'82\'b7\'81\'42
-\f1 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-
-\fs22 \cf3 \
-\pard\tx565\tx1133\tx1700\tx2266\tx2832\tx3401\tx3967\tx4535\tx5102\tx5669\tx6235\tx6802\pardeftab529\sl264\slmult1
-\cf3 Copyright (c) 2013 Andrew Sliwinski\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy\
-of this software and associated documentation files (the "Software"), to deal\
-in the Software without restriction, including without limitation the rights\
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
-copies of the Software, and to permit persons to whom the Software is\
-furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in\
-all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\
-THE SOFTWARE.\CocoaLigature0 \
-\pard\tx529\pardeftab529\sl264\slmult1\pardirnatural
+SOFTWARE.\
 
 \fs24 \cf0 \CocoaLigature1 \
+\
 \pard\tx565\tx1133\tx1700\tx2266\tx2832\tx3401\tx3967\tx4535\tx5102\tx5669\tx6235\tx6802\pardeftab529\sl264\slmult1
 
 \b \cf0 Solarized

--- a/CotEditor/zh-Hans.lproj/Acknowledgements.rtf
+++ b/CotEditor/zh-Hans.lproj/Acknowledgements.rtf
@@ -193,8 +193,7 @@ SUCH DAMAGE.\
 \f1 \'d6\'a4\'b7\'a2
 \f0 \'95\'7a\'93\'49\'81\'46
 \f2  \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\sl264\slmult1
-\cf0 \CocoaLigature0 \
+\CocoaLigature0 \
 \pard\tx529\pardeftab529\sl264\slmult1\pardirnatural
 
 \fs22 \cf3 \'a9 2006-2013 Andy Matuschak\
@@ -310,54 +309,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\
 SOFTWARE.
 \fs24 \cf0 \CocoaLigature1 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-\cf0 \
-\
-\pard\tx565\tx1133\tx1700\tx2266\tx2832\tx3401\tx3967\tx4535\tx5102\tx5669\tx6235\tx6802\pardeftab529\sl264\slmult1
-
-\b \cf0 EDSemVer
-\b0   ({\field{\*\fldinst{HYPERLINK "https://github.com/thisandagain/semver"}}{\fldrslt https://github.com/thisandagain/semver}})\
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-
-\f0 \cf0 \'8a\'b4
-\f1 \'d0\'bb
-\f2  Andrew Sliwinski 
-\f0 \'93\'49
-\f2  EDSemVer
-\f0 \'81\'43
-\f1 \'d5\'e2\'ca\'c7\'d2\'bb\'b8\'f6\'d3\'ef\'d2\'e5
-\f0 \'94\'c5\'96\'7b\'8d\'86\'89\'f0\'90\'cd\'8a\'ed\'81\'42
-\f2 EDSemVer 
-\f0 \'90\'a5\'8f\'85\'8f\'7a\'94\'40\'89\'ba MIT 
-\f1 \'d0\'ed
-\f0 \'89\'c2
-\f1 \'d6\'a4\'b7\'a2
-\f0 \'95\'7a\'93\'49\'81\'46
-\f2 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
-
-\fs22 \cf3 \
-\pard\tx565\tx1133\tx1700\tx2266\tx2832\tx3401\tx3967\tx4535\tx5102\tx5669\tx6235\tx6802\pardeftab529\sl264\slmult1
-\cf3 Copyright (c) 2013 Andrew Sliwinski\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy\
-of this software and associated documentation files (the "Software"), to deal\
-in the Software without restriction, including without limitation the rights\
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\
-copies of the Software, and to permit persons to whom the Software is\
-furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in\
-all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\
-THE SOFTWARE.
-\fs24 \cf0 \
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardeftab529\sl264\slmult1
 \cf0 \
 \

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,6 @@ def shared_pods
         :git => 'https://github.com/coteditor/YAML.framework.git',
         :branch => 'coteditor-mod'
     pod 'WFColorCode'
-    pod 'EDSemver'
 end
 
 # non-AppStore target

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - EDSemver (0.3.0)
   - LibYAML (0.1.4)
   - OgreKit (2.1.7.8)
   - Sparkle (1.11.0)
@@ -8,7 +7,6 @@ PODS:
     - LibYAML (~> 0.1.4)
 
 DEPENDENCIES:
-  - EDSemver
   - OgreKit (from `https://github.com/coteditor/OgreKit.git`, branch `coteditor-mod`)
   - Sparkle
   - WFColorCode
@@ -32,7 +30,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/coteditor/YAML.framework.git
 
 SPEC CHECKSUMS:
-  EDSemver: 124a90685873628ec30f42504b461a1a61757568
   LibYAML: 3af2c5adf3a40dff936d087aa6a77edc10036bc5
   OgreKit: 1574a7a6badb9d4e04a7fcb7fcabbbd9903da652
   Sparkle: cf10103ef35fd89caa35373bfd772c5d6f9c7d73


### PR DESCRIPTION
To resolve issue #419, CotEditor's versioning system has been changed to the following:

- __Build Number__ (CFBundleVersion) : A pure integer 
- __Version Number__ (CFBundleShortVersionString) : 
    - Stable Releases -> Contains only [0-9.]
    - Pre-Releases -> MUST contains at least one non-digit letter.

Note that the version number stability comparing is used on Sparkle things.


---

Issue #419 をうけて、バージョンシステムを以下のように変更しました。

- __ビルド番号__ (CFBundleVersion) : 純粋な整数値
- __バージョン__ (CFBundleShortVersionString) : 
    - 安定版 -> [0-9.] のみから成り立つ
    - プレリリース版 -> 最低1つ以上の数字以外の文字を含む

バージョンの安定版／プレリリース版の比較は Sparkle のプレリリースチェックの切り替えに使用されます。従来通り β, RC などの文字が続けば、プレリリース版と判断されます。ただの 2.2.0 など数値とドットのみの場合は安定版とみなします。

本来ただのお飾りの CFBundleShortVersionString を値として取り回すことに若干抵抗がなくもないのですが、まぁ妥当かなとも思います。BundleVersion の方に b などの数字を足すという手もありますがCFBundleShortVersionStringの方は常に整数をキープした方が無難な気がします。

仕様的に妥当そうならマージお願いします。もっといい案があればご提案ください。