### PR TITLE
Expose autoExpandTab for plugins that handle coding styles

### DIFF
--- a/CotEditor/CotEditor.sdef
+++ b/CotEditor/CotEditor.sdef
@@ -75,6 +75,9 @@
             <property name="tab width" code="tbwd" type="integer" access="rw" description="The width of a tab character in space equivalents.">
                 <cocoa key="tabWidth"/>
             </property>
+            <property name="auto expand tab" code="aetb" type="boolean" access="rw" description="Are a tab character expanded to space?">
+                <cocoa key="autoExpandTab"/>
+            </property>
             <property name="selection" code="sele" type="text selection" access="rw" description="The current selection.">
                 <cocoa key="selectionObject"/>
             </property>

--- a/CotEditor/CotEditor.sdef
+++ b/CotEditor/CotEditor.sdef
@@ -75,8 +75,8 @@
             <property name="tab width" code="tbwd" type="integer" access="rw" description="The width of a tab character in space equivalents.">
                 <cocoa key="tabWidth"/>
             </property>
-            <property name="auto expand tab" code="aetb" type="boolean" access="rw" description="Are a tab character expanded to space?">
-                <cocoa key="autoExpandTab"/>
+            <property name="expands tab" code="extb" type="boolean" access="rw" description="Are tab characters expanded to space?">
+                <cocoa key="expandsTab"/>
             </property>
             <property name="selection" code="sele" type="text selection" access="rw" description="The current selection.">
                 <cocoa key="selectionObject"/>

--- a/CotEditor/Sources/Document+ScriptingSupport.swift
+++ b/CotEditor/Sources/Document+ScriptingSupport.swift
@@ -183,13 +183,13 @@ extension Document {
     
     
     /// whether replace tab with spaces
-    var autoExpandTab: NSNumber {
+    var expandsTab: NSNumber {
         
         get {
             return NSNumber(value :self.viewController?.isAutoTabExpandEnabled ?? false)
         }
-        set (autoExpandTab) {
-            self.viewController?.isAutoTabExpandEnabled = autoExpandTab.boolValue
+        set (expandsTab) {
+            self.viewController?.isAutoTabExpandEnabled = expandsTab.boolValue
         }
     }
     

--- a/CotEditor/Sources/Document+ScriptingSupport.swift
+++ b/CotEditor/Sources/Document+ScriptingSupport.swift
@@ -182,6 +182,18 @@ extension Document {
     }
     
     
+    /// whether replace tab with spaces
+    var autoExpandTab: NSNumber {
+        
+        get {
+            return NSNumber(value :self.viewController?.isAutoTabExpandEnabled ?? false)
+        }
+        set (autoExpandTab) {
+            self.viewController?.isAutoTabExpandEnabled = autoExpandTab.boolValue
+        }
+    }
+    
+    
     
     // MARK: AppleScript Handler
     

--- a/CotEditor/Sources/DocumentViewController.swift
+++ b/CotEditor/Sources/DocumentViewController.swift
@@ -748,7 +748,7 @@ final class DocumentViewController: NSSplitViewController, SyntaxStyleDelegate, 
     
     
     /// whether replace tab with spaces
-    private var isAutoTabExpandEnabled: Bool {
+    var isAutoTabExpandEnabled: Bool {
         
         get {
             guard let textView = self.focusedTextView else {

--- a/CotEditor/Sources/EditorTextView.swift
+++ b/CotEditor/Sources/EditorTextView.swift
@@ -46,6 +46,8 @@ final class EditorTextView: NSTextView, Themable {
     
     // MARK: Public Properties
     
+    var isAutomaticTabExpansionEnabled = false
+    
     var lineHighlightRect: NSRect?
     
     var inlineCommentDelimiter: String?
@@ -829,16 +831,6 @@ final class EditorTextView: NSTextView, Themable {
                 tabWidth = oldValue
             }
             guard tabWidth != oldValue else { return }
-            
-            // apply to view
-            self.invalidateDefaultParagraphStyle()
-        }
-    }
-    
-    /// whether replace tab with spaces
-    var isAutomaticTabExpansionEnabled: Bool {
-        didSet {
-            guard isAutomaticTabExpansionEnabled != oldValue else { return }
             
             // apply to view
             self.invalidateDefaultParagraphStyle()

--- a/CotEditor/Sources/EditorTextView.swift
+++ b/CotEditor/Sources/EditorTextView.swift
@@ -46,8 +46,6 @@ final class EditorTextView: NSTextView, Themable {
     
     // MARK: Public Properties
     
-    var isAutomaticTabExpansionEnabled = false
-    
     var lineHighlightRect: NSRect?
     
     var inlineCommentDelimiter: String?
@@ -831,6 +829,16 @@ final class EditorTextView: NSTextView, Themable {
                 tabWidth = oldValue
             }
             guard tabWidth != oldValue else { return }
+            
+            // apply to view
+            self.invalidateDefaultParagraphStyle()
+        }
+    }
+    
+    /// whether replace tab with spaces
+    var isAutomaticTabExpansionEnabled: Bool {
+        didSet {
+            guard isAutomaticTabExpansionEnabled != oldValue else { return }
             
             // apply to view
             self.invalidateDefaultParagraphStyle()


### PR DESCRIPTION
I want CotEditor to support [EditorConfig](http://editorconfig.org) and created [the JXA plugin](https://github.com/umireon/coteditor-editorconfig) which includes [the port of editorconfig core on JXA (JavaScript for Automation)](https://github.com/umireon/editorconfig-jxa).

EditorConfig manages the following coding styles on the project basis:
* Indent size and Indent style (tab or space)
* Charset and Line ending (LF, CR, or CRLF)
* Trailing whitespace and newline at EOF

However, CotEditor scripting support exposes the limited number of properties for coding style such as indent size and line endings.

I think supporting more of them is great for the situation that another editor is used with CotEditor.

## Changeset Description
Plugins for managing coding styles such as EditorConfig are usually
expected to control the indent size and tab expansion.

This change allows plugins to change the behavior of tab expansion.

---

I decided to make this PR without issue because the changeset is quite small.
I would appreciate any discussions 😃
