### PR TITLE
Add support for script bundles

### DIFF
--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -98,7 +98,7 @@ class Script {
 
 final class AppleScript: Script {
     
-    static let extensions = ["applescript", "scpt"]
+    static let extensions = ["applescript", "scpt", "scptd"]
     
     
     // MARK: Script Methods

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -234,18 +234,7 @@ final class ScriptManager: NSObject, NSFilePresenter {
             
             guard let resourceType = (try? url.resourceValues(forKeys: [.fileResourceTypeKey]))?.fileResourceType else { continue }
             
-            switch resourceType {
-            case URLFileResourceType.directory:
-                let submenu = NSMenu(title: title)
-                let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-                item.tag = MainMenu.MenuItemTag.scriptDirectory.rawValue
-                menu.addItem(item)
-                item.submenu = submenu
-                self.addChildFileItem(to: submenu, in: url)
-                
-            case URLFileResourceType.regular:
-                guard (AppleScript.extensions + ShellScript.extensions).contains(url.pathExtension) else { continue }
-                
+            if (AppleScript.extensions + ShellScript.extensions).contains(url.pathExtension) {
                 let shortcut = self.shortcut(from: url)
                 let item = NSMenuItem(title: title, action: #selector(launchScript), keyEquivalent: shortcut.keyEquivalent)
                 item.keyEquivalentModifierMask = shortcut.modifierMask
@@ -253,8 +242,13 @@ final class ScriptManager: NSObject, NSFilePresenter {
                 item.target = self
                 item.toolTip = NSLocalizedString("“Option + click” to open script in editor.", comment: "")
                 menu.addItem(item)
-                
-            default: break
+            } else if resourceType == URLFileResourceType.directory {
+                let submenu = NSMenu(title: title)
+                let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+                item.tag = MainMenu.MenuItemTag.scriptDirectory.rawValue
+                menu.addItem(item)
+                item.submenu = submenu
+                self.addChildFileItem(to: submenu, in: url)
             }
         }
     }


### PR DESCRIPTION
A script bundle is the directory that has `.scptd` extension and contains a single entry point and required libraries.

![editorconfig scptd 2016-12-03 02-40-11](https://cloud.githubusercontent.com/assets/1067855/20844143/d62590a8-b901-11e6-8598-ae4492cd0906.png)

Script bundles has the directory structure but everything else is the same as single scripts.
Thus supporting `*.scptd` as well as `*.scpt` is reasonable.

This change adds support for script bundles (`.scptd`) as they behave exactly in the same manner as single scripts (`.scpt`) do.

Background: Currently, the EditorConfig plugin consists of multiple modules and must be bundled by webpack. I can remove such thingies with support of script bundle.