### PR TITLE
Feature request: Scripting hook

### DIFF
--- a/CotEditor/CotEditor.sdef
+++ b/CotEditor/CotEditor.sdef
@@ -329,6 +329,11 @@
         <event name="document opened" code="cEd1edod" description="This handler is called when CotEditor opened a document.">
             <direct-parameter type="document" description="The document that opened."/>
         </event>
+        
+        <!-- handle [e]vent [d]ocument [s]ave[d] -->
+        <event name="document saved" code="cEd1edsd" description="This handler is called when CotEditor saved a document.">
+            <direct-parameter type="document" description="The document that saved."/>
+        </event>
     </suite>
     
     

--- a/CotEditor/CotEditor.sdef
+++ b/CotEditor/CotEditor.sdef
@@ -324,6 +324,14 @@
     </suite>
     
     
+    <suite name="CotEditor Event Handler suite" code="cEd1" description="commands that are executed as CotEditor event handlers.">
+        <!-- handle [e]vent [d]ocument [o]pene[d] -->
+        <event name="document opened" code="cEd1edod" description="This handler is called when CotEditor opened a document.">
+            <direct-parameter type="document" description="The document that opened."/>
+        </event>
+    </suite>
+    
+    
     <!-- imported standard Text Suite -->
     <suite name="Text Suite" code="????" description="Common text classes for all applications.">
         <access-group identifier="*"/>

--- a/CotEditor/Sources/Document.swift
+++ b/CotEditor/Sources/Document.swift
@@ -337,8 +337,6 @@ final class Document: NSDocument, AdditionalDocumentPreparing, EncodingHolder {
             ?? Defaults[.syntaxStyle]
         
         self.setSyntaxStyle(name: styleName)
-        
-        ScriptManager.shared.dispatchEvent(documentOpened: self)
     }
     
     
@@ -452,7 +450,6 @@ final class Document: NSDocument, AdditionalDocumentPreparing, EncodingHolder {
                 }
             }
         }
-        
     }
     
     
@@ -773,6 +770,8 @@ final class Document: NSDocument, AdditionalDocumentPreparing, EncodingHolder {
         if Defaults[.savesTextOrientation] {
             self.isVerticalText = ((self.fileAttributes?[NSFileExtendedAttributes] as? [String: Any])?[FileExtendedAttributeName.VerticalText] != nil)
         }
+        
+        ScriptManager.shared.dispatchEvent(documentOpened: self)
     }
     
     

--- a/CotEditor/Sources/Document.swift
+++ b/CotEditor/Sources/Document.swift
@@ -439,7 +439,20 @@ final class Document: NSDocument, AdditionalDocumentPreparing, EncodingHolder {
                 let odbEventType: ODBEventSender.EventType = (saveOperation == .saveAsOperation) ? .newLocation : .modified
                 self?.odbEventSender?.sendEvent(type: odbEventType, fileURL: url)
             }
+            
+            if let document = self {
+                switch saveOperation {
+                case .saveAsOperation:
+                    fallthrough
+                case .saveOperation:
+                    fallthrough
+                case .saveToOperation:
+                    ScriptManager.shared.dispatchEvent(documentSaved: document)
+                default: break
+                }
+            }
         }
+        
     }
     
     

--- a/CotEditor/Sources/Document.swift
+++ b/CotEditor/Sources/Document.swift
@@ -337,6 +337,8 @@ final class Document: NSDocument, AdditionalDocumentPreparing, EncodingHolder {
             ?? Defaults[.syntaxStyle]
         
         self.setSyntaxStyle(name: styleName)
+        
+        ScriptManager.shared.dispatchEvent(documentOpened: self)
     }
     
     

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -113,7 +113,18 @@ final class AppleScript: Script {
     /// run script
     /// - throws: Error by NSUserScriptTask
     override func run() throws {
-        
+        try self.run(withAppleEvent: nil)
+    }
+    
+    /// Execute the AppleScript script by sending it the given Apple event.
+    ///
+    /// Any script errors will be written to the console panel.
+    ///
+    /// - parameter event: the apple event
+    ///
+    /// - throws: `ScriptFileError` and any errors by `NSUserScriptTask.init(url:)`
+    ///           
+    func run(withAppleEvent event: NSAppleEventDescriptor?) throws {
         guard self.url.isReachable else {
             throw ScriptFileError(kind: .existance, url: self.url)
         }
@@ -121,7 +132,7 @@ final class AppleScript: Script {
         let task = try NSUserAppleScriptTask(url: self.url)
         let scriptName = self.name
         
-        task.execute(withAppleEvent: nil) { (result: NSAppleEventDescriptor?, error: Error?) in
+        task.execute(withAppleEvent: event) { (result: NSAppleEventDescriptor?, error: Error?) in
             if let error = error {
                 Script.writeToConsole(message: error.localizedDescription, scriptName: scriptName)
             }

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -241,10 +241,9 @@ final class ScriptManager: NSObject, NSFilePresenter {
     func createEvent(by document: Document, eventID: AEEventID) -> NSAppleEventDescriptor {
         let event = NSAppleEventDescriptor(eventClass: AEEventClass(code: "cEd1"), eventID: eventID, targetDescriptor: nil, returnID: AEReturnID(kAutoGenerateReturnID), transactionID: AETransactionID(kAnyTransactionID))
         
-        //
-        let documentDescriptor = document.objectSpecifier.descriptor!
-        
-        event.setParam(documentDescriptor, forKeyword: keyDirectObject)
+        if let documentDescriptor = document.objectSpecifier.descriptor {
+            event.setParam(documentDescriptor, forKeyword: keyDirectObject)
+        }
         
         return event
     }

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -233,6 +233,11 @@ final class ScriptManager: NSObject, NSFilePresenter {
     
     /// Create an Apple event caused by the given `Document`
     ///
+    /// - bug:
+    ///   NSScriptObjectSpecifier.descriptor can be nil.
+    ///   If `nil`, the error is propagated by passing a string in place of `Document`.
+    ///   [#649](https://github.com/coteditor/CotEditor/pull/649)
+    ///
     /// - parameters:
     ///   - document: the document to dispatch an Apple event
     ///   - eventID: the event ID to be set in the returned event
@@ -241,9 +246,8 @@ final class ScriptManager: NSObject, NSFilePresenter {
     func createEvent(by document: Document, eventID: AEEventID) -> NSAppleEventDescriptor {
         let event = NSAppleEventDescriptor(eventClass: AEEventClass(code: "cEd1"), eventID: eventID, targetDescriptor: nil, returnID: AEReturnID(kAutoGenerateReturnID), transactionID: AETransactionID(kAnyTransactionID))
         
-        if let documentDescriptor = document.objectSpecifier.descriptor {
-            event.setParam(documentDescriptor, forKeyword: keyDirectObject)
-        }
+        let documentDescriptor = document.objectSpecifier.descriptor ?? NSAppleEventDescriptor(string: "BUG: document.objectSpecifier.descriptor was nil")
+        event.setParam(documentDescriptor, forKeyword: keyDirectObject)
         
         return event
     }

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -220,6 +220,17 @@ final class ScriptManager: NSObject, NSFilePresenter {
     }
     
     
+    /// Dispatch an Apple event that notifies the given document was opened
+    ///
+    /// - parameter document: the document that was opened
+    func dispatchEvent(documentSaved document: Document) {
+        let event = createEvent(by: document, eventID: AEEventID(code: "edsd"))
+        if let urls = self.scriptHandlersTable["document saved"] {
+            self.dispatch(event, toHandlersAt: urls)
+        }
+    }
+    
+    
     /// Create an Apple event caused by the given `Document`
     ///
     /// - parameters:

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -209,6 +209,36 @@ final class ScriptManager: NSObject, NSFilePresenter {
     }
     
     
+    /// Dispatch an Apple event that notifies the given document was opened
+    ///
+    /// - parameter document: the document that was opened
+    func dispatchEvent(documentOpened document: Document) {
+        let event = createEvent(by: document, eventID: AEEventID(code: "edod"))
+        if let urls = self.scriptHandlersTable["document opened"] {
+            self.dispatch(event, toHandlersAt: urls)
+        }
+    }
+    
+    
+    /// Create an Apple event caused by the given `Document`
+    ///
+    /// - parameters:
+    ///   - document: the document to dispatch an Apple event
+    ///   - eventID: the event ID to be set in the returned event
+    ///
+    /// - returns: a descriptor for an Apple event by the `Document`
+    func createEvent(by document: Document, eventID: AEEventID) -> NSAppleEventDescriptor {
+        let event = NSAppleEventDescriptor(eventClass: AEEventClass(code: "cEd1"), eventID: eventID, targetDescriptor: nil, returnID: AEReturnID(kAutoGenerateReturnID), transactionID: AETransactionID(kAnyTransactionID))
+        
+        //
+        let documentDescriptor = document.objectSpecifier.descriptor!
+        
+        event.setParam(documentDescriptor, forKeyword: keyDirectObject)
+        
+        return event
+    }
+    
+    
     /// Cause the given Apple event to be dispatched to AppleScripts at given URLs.
     ///
     /// - parameters:


### PR DESCRIPTION
As the author of the EditorConfig plugin for CotEditor,
I want scripting hooks such as onload and onsave to be integrated in CotEditor,
To make the plugin works seamlessly (ie without additional user interaction).

Script bundles have `Contents/Info.plist`, which can contain additional meta data for the bundle.
Given the following property list:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>CotEditorHandlers</key>
  <array>
    <string>document opened</string>
    <string>document saved</string>
  </array>
</dict>
</plist>
```

CotEditor can configure the scripting hook only by reading Info.plist.
Note that a property list can be parsed easily with `NSDictionary`.

Finally, Event delivery with AppleScript can be implemented with Apple Event.
Example: [Messages.app](https://discussions.apple.com/thread/6476545?tstart=0)

The basic concept of this proposal is based on the discussion in #513.
The following points is also carefully considered:
* No startup delay: Hook registration can be performed without any external code execution
* No user configuration: Hook configuration is contained in plugin itself
* Compatible with AppleScript and JXA: Hook is written in the form of handler

## Changeset Description
Add hook mechanics for AppleScript plugins

Script bundles can have `Info.plist`, which is useful to store metadata.
For example, the following key-value set can be used to determine
whether the event of document opened should delivered to the plugin:

```
<key>CotEditorHandlers</key>
<array>
<string>document opened</string>
</array>
```

By this change, the `CotEditorHandlers` in `Info.plist` of script bundle
lugins will be read and registered to `ScriptManager`.

Additionally, the API to invoke the registered handlers was introduced:
  `ScriptManager.dispatch(_:toHandlersAt)`

The following scripting events added:
* document opened
* document saved