### PR TITLE
Do not use enum-based event dispatcher in Swift

### DIFF
--- a/CotEditor/Sources/Document.swift
+++ b/CotEditor/Sources/Document.swift
@@ -439,7 +439,7 @@ final class Document: NSDocument, AdditionalDocumentPreparing, EncodingHolder {
             }
             
             if saveOperation == .saveToOperation, let strongSelf = self {
-                ScriptManager.shared.dispatchEvent(for: .documentSaved, document: strongSelf)
+                ScriptManager.shared.dispatchEvent(documentSaved: strongSelf)
             }
         }
     }
@@ -763,7 +763,7 @@ final class Document: NSDocument, AdditionalDocumentPreparing, EncodingHolder {
             self.isVerticalText = ((self.fileAttributes?[NSFileExtendedAttributes] as? [String: Any])?[FileExtendedAttributeName.VerticalText] != nil)
         }
         
-        ScriptManager.shared.dispatchEvent(for: .documentOpened, document: self)
+        ScriptManager.shared.dispatchEvent(documentOpened: self)
     }
     
     


### PR DESCRIPTION
This reverts commit 349b671537c42a5723d57ee08ce2f958e65ba1dd partially.

Enum-based event dispatcher is completely wrong.
* Future extensibility is very bad. No clean way to add parameter for another event.
* The type safety of Swift will be ruined. Type strictly as the delegates with protocol does.

Guess what happens if we want to add `isAutoSave` parameter to the event.