### PR TITLE
Refactoring user script relevant classes

### DIFF
--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -156,6 +156,23 @@ protocol Script {
     func run() throws
     
     
+    /// Execute the script by sending it the given Apple event.
+    ///
+    /// Events the script cannot handle must be ignored with no errors.
+    func run(withAppleEvent event: NSAppleEventDescriptor?) throws
+    
+    
+}
+
+
+
+extension Script {
+    
+    func run(withAppleEvent event: NSAppleEventDescriptor?) throws {
+        // ignore every request with an event by default
+    }
+    
+    
 }
 
 

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -102,7 +102,7 @@ class AbstractScript : Script {
 
 // MARK: -
 
-final class AppleScript: AbstractScript {
+class AppleScript: AbstractScript {
     
     static let extensions = ["applescript", "scpt", "scptd"]
     
@@ -152,7 +152,7 @@ final class AppleScript: AbstractScript {
 
 
 
-final class ShellScript: AbstractScript {
+class ShellScript: AbstractScript {
     
     static let extensions = ["sh", "pl", "php", "rb", "py", "js"]
     

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -144,9 +144,8 @@ class ScriptDescriptor {
 
 
 protocol Script {
+    var url: URL { get }
     func run() throws
-    func reveal() throws
-    func edit() throws
 }
 
 class AbstractScript : Script {
@@ -170,34 +169,6 @@ class AbstractScript : Script {
     // MARK: Abstracts Methods
     
     func run() throws { preconditionFailure() }
-    
-    
-    
-    // MARK: Public Methods
-    
-    /// open script file in an editor
-    /// - throws: ScriptFileError
-    func edit() throws {
-        
-        guard NSWorkspace.shared().open(self.url) else {
-            // display alert if cannot open/select the script file
-            throw ScriptFileError(kind: .open, url: self.url)
-        }
-    }
-    
-    
-    /// reveal script file in Finder
-    /// - throws: ScriptFileError
-    func reveal() throws {
-        
-        guard self.url.isReachable else {
-            throw ScriptFileError(kind: .existance, url: self.url)
-        }
-        
-        NSWorkspace.shared().activateFileViewerSelecting([self.url])
-    }
-    
-    
     
     // MARK: Private Methods
     

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -56,7 +56,7 @@ enum ScriptingFileType {
 
 
 
-class ScriptDescriptor {
+final class ScriptDescriptor {
     
     // MARK: Public Properties
     
@@ -191,7 +191,7 @@ extension Script {
 
 // MARK: -
 
-class AppleScript: Script {
+final class AppleScript: Script {
     
     // MARK: Script Properties
     
@@ -247,7 +247,7 @@ class AppleScript: Script {
 
 
 
-class ShellScript: Script {
+final class ShellScript: Script {
     
     // MARK: Script Properties
     

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -28,7 +28,13 @@
 
 import Cocoa
 
-class Script {
+protocol Script {
+    func run() throws
+    func reveal() throws
+    func edit() throws
+}
+
+class AbstractScript : Script {
     
     let url: URL
     let name: String
@@ -96,7 +102,7 @@ class Script {
 
 // MARK: -
 
-final class AppleScript: Script {
+final class AppleScript: AbstractScript {
     
     static let extensions = ["applescript", "scpt", "scptd"]
     
@@ -137,7 +143,7 @@ final class AppleScript: Script {
         
         task.execute(withAppleEvent: event) { (result: NSAppleEventDescriptor?, error: Error?) in
             if let error = error {
-                Script.writeToConsole(message: error.localizedDescription, scriptName: scriptName)
+                AbstractScript.writeToConsole(message: error.localizedDescription, scriptName: scriptName)
             }
         }
     }
@@ -146,7 +152,7 @@ final class AppleScript: Script {
 
 
 
-final class ShellScript: Script {
+final class ShellScript: AbstractScript {
     
     static let extensions = ["sh", "pl", "php", "rb", "py", "js"]
     
@@ -208,7 +214,7 @@ final class ShellScript: Script {
             do {
                 input = try self.readInputString(type: inputType, editor: document)
             } catch let error {
-                Script.writeToConsole(message: error.localizedDescription, scriptName: self.name)
+                AbstractScript.writeToConsole(message: error.localizedDescription, scriptName: self.name)
                 return
             }
         } else {
@@ -262,7 +268,7 @@ final class ShellScript: Script {
                 do {
                     try ShellScript.applyOutput(output, editor: document, type: outputType)
                 } catch let error {
-                    Script.writeToConsole(message: error.localizedDescription, scriptName: scriptName)
+                    AbstractScript.writeToConsole(message: error.localizedDescription, scriptName: scriptName)
                 }
             }
         }
@@ -278,7 +284,7 @@ final class ShellScript: Script {
             // put error message on the sconsole
             let errorData = errPipe.fileHandleForReading.readDataToEndOfFile()
             if let message = String(data: errorData, encoding: .utf8), !message.isEmpty {
-                Script.writeToConsole(message: message, scriptName: scriptName)
+                AbstractScript.writeToConsole(message: message, scriptName: scriptName)
             }
         }
     }

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -55,7 +55,7 @@ enum ScriptingFileType {
 
 
 
-final class ScriptDescriptor {
+struct ScriptDescriptor {
     
     // MARK: Public Properties
     
@@ -80,62 +80,53 @@ final class ScriptDescriptor {
     // MARK: -
     // MARK: Public Methods
     
-    /// Create a descriptor, initialized according to the specified information.
-    init(url: URL, name: String, type: ScriptingFileType?, shortcut: Shortcut = Shortcut.none, eventTypes: [ScriptingEventType] = [], ordering: Int?) {
-        self.url = url
-        self.name = name
-        self.type = type
-        self.shortcut = shortcut
-        self.eventTypes = eventTypes
-        self.ordering = ordering
-    }
-    
-    
     /// Create a descriptor that represents an user script at given URL.
     ///
     /// `Contents/Info.plist` in the script at `url` will be read if they exist.
     ///
     /// - parameter url: the location of an user script
-    convenience init(at url: URL) {
+    init(at url: URL) {
         
         // Extract from URL
         
-        let type = ScriptDescriptor.extensions.first { $0.value.contains(url.pathExtension) }?.key
+        self.url = url
+        
+        self.type = ScriptDescriptor.extensions.first { $0.value.contains(url.pathExtension) }?.key
         
         var name = url.deletingPathExtension().lastPathComponent
         
-        var shortcut = Shortcut(keySpecChars: url.deletingPathExtension().pathExtension)
+        let shortcut = Shortcut(keySpecChars: url.deletingPathExtension().pathExtension)
         if shortcut.modifierMask.isEmpty {
-            shortcut = Shortcut.none
+            self.shortcut = Shortcut.none
         } else {
+            self.shortcut = shortcut
+            
             // Remove the shortcut specification from the script name
             name = URL(fileURLWithPath: name).deletingPathExtension().lastPathComponent
         }
         
-        let ordering: Int?
         if let range = name.range(of: "^[0-9]+\\)", options: .regularExpression) {
             // Remove the parenthesis at last
             let orderingString = name.substring(to: name.index(before: range.upperBound))
-            ordering = Int(orderingString)
+            self.ordering = Int(orderingString)
             
             // Remove the ordering number from the script name
             name.removeSubrange(range)
         } else {
-            ordering = nil
+            self.ordering = nil
         }
+        
+        self.name = name
         
         // Extract from Info.plist
         
         let info = NSDictionary(contentsOf: url.appendingPathComponent("Contents/Info.plist"))
         
-        let eventTypes: [ScriptingEventType]
         if let names = info?["CotEditorHandlers"] as? [String] {
-            eventTypes = names.flatMap { ScriptingEventType(rawValue: $0) }
+            self.eventTypes = names.flatMap { ScriptingEventType(rawValue: $0) }
         } else {
-            eventTypes = []
+            self.eventTypes = []
         }
-        
-        self.init(url: url, name: name, type: type, shortcut: shortcut, eventTypes: eventTypes, ordering: ordering)
     }
     
     

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -50,7 +50,6 @@ enum ScriptingFileType {
     
     case appleScript
     case shellScript
-    case unknown
     
 }
 
@@ -62,7 +61,7 @@ final class ScriptDescriptor {
     
     let url: URL
     let name: String
-    let type: ScriptingFileType
+    let type: ScriptingFileType?
     let shortcut: Shortcut
     let eventTypes: [ScriptingEventType]
     let ordering: Int?
@@ -82,7 +81,7 @@ final class ScriptDescriptor {
     // MARK: Public Methods
     
     /// Create a descriptor, initialized according to the specified information.
-    init(url: URL, name: String, type: ScriptingFileType, shortcut: Shortcut = Shortcut.none, eventTypes: [ScriptingEventType] = [], ordering: Int?) {
+    init(url: URL, name: String, type: ScriptingFileType?, shortcut: Shortcut = Shortcut.none, eventTypes: [ScriptingEventType] = [], ordering: Int?) {
         self.url = url
         self.name = name
         self.type = type
@@ -101,7 +100,7 @@ final class ScriptDescriptor {
         
         // Extract from URL
         
-        let type = ScriptDescriptor.extensions.first { $0.value.contains(url.pathExtension) }?.key ?? .unknown
+        let type = ScriptDescriptor.extensions.first { $0.value.contains(url.pathExtension) }?.key
         
         var name = url.deletingPathExtension().lastPathComponent
         
@@ -145,10 +144,12 @@ final class ScriptDescriptor {
     /// - returns: An instance of `Script` created by the receiver.
     ///            Returns `nil` if the script type is unsupported.
     func makeScript() -> Script? {
-        switch self.type {
+        
+        guard let type = self.type else { return nil }
+        
+        switch type {
         case .appleScript: return AppleScript(with: self)
         case .shellScript: return ShellScript(with: self)
-        case .unknown: return nil
         }
     }
 }

--- a/CotEditor/Sources/Script.swift
+++ b/CotEditor/Sources/Script.swift
@@ -169,7 +169,6 @@ class AbstractScript : Script {
     
     // MARK: Abstracts Methods
     
-    fileprivate var editorIdentifier: String { preconditionFailure() }
     func run() throws { preconditionFailure() }
     
     
@@ -180,7 +179,7 @@ class AbstractScript : Script {
     /// - throws: ScriptFileError
     func edit() throws {
         
-        guard NSWorkspace.shared().open([self.url], withAppBundleIdentifier: self.editorIdentifier, additionalEventParamDescriptor: nil, launchIdentifiers: nil) else {
+        guard NSWorkspace.shared().open(self.url) else {
             // display alert if cannot open/select the script file
             throw ScriptFileError(kind: .open, url: self.url)
         }
@@ -223,13 +222,6 @@ class AppleScript: AbstractScript {
     
     
     // MARK: Script Methods
-    
-    /// bundle identifier of appliation to edit script
-    override var editorIdentifier: String {
-        
-        return BundleIdentifier.ScriptEditor
-    }
-    
     
     /// run script
     /// - throws: Error by NSUserScriptTask
@@ -297,13 +289,6 @@ class ShellScript: AbstractScript {
     
     
     // MARK: Script Methods
-    
-    /// bundle identifier of appliation to edit script
-    override var editorIdentifier: String {
-        
-        return Bundle.main.bundleIdentifier!
-    }
-    
     
     /// run script
     /// - throws: ScriptFileError or Error by NSUserScriptTask

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -270,7 +270,7 @@ final class ScriptManager: NSObject, NSFilePresenter {
     private func dispatch(_ event: NSAppleEventDescriptor, toHandlersAt urls: [URL]) {
         
         for url in urls {
-            guard let script = self.scripts[url] as? AppleScript else { continue }
+            guard let script = self.scripts[url] else { continue }
             do {
                 try script.run(withAppleEvent: event)
             } catch let error {

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -58,6 +58,7 @@ final class ScriptManager: NSObject, NSFilePresenter {
     private let scriptsDirectoryURL: URL
     private var didChangeFolder = false
     private var scriptHandlersTable: [ScriptingEventType: [URL]] = [:]
+    private var scripts: [URL: Script] = [:]
     
     
     
@@ -171,6 +172,8 @@ final class ScriptManager: NSObject, NSFilePresenter {
         
         self.scriptHandlersTable = [:]
         
+        self.scripts = [:]
+        
         self.addChildFileItem(to: menu, in: self.scriptsDirectoryURL)
         
         if !menu.items.isEmpty {
@@ -223,16 +226,7 @@ final class ScriptManager: NSObject, NSFilePresenter {
         
         guard let url = sender?.representedObject as? URL else { return }
         
-        let scriptName = self.scriptName(from: url)
-        
-        let script: Script
-        if AppleScript.extensions.contains(url.pathExtension) {
-            script = AppleScript(url: url, name: scriptName)
-        } else if ShellScript.extensions.contains(url.pathExtension) {
-            script = ShellScript(url: url, name: scriptName)
-        } else {
-            return
-        }
+        guard let script = self.scripts[url] else { return }
         
         do {
             // change behavior if modifier key is pressed
@@ -338,6 +332,12 @@ final class ScriptManager: NSObject, NSFilePresenter {
                 item.toolTip = NSLocalizedString("“Option + click” to open script in editor.", comment: "")
                 menu.addItem(item)
                 
+                let scriptName = self.scriptName(from: url)
+                if AppleScript.extensions.contains(url.pathExtension) {
+                    self.scripts[url] = AppleScript(url: url, name: scriptName)
+                } else if ShellScript.extensions.contains(url.pathExtension) {
+                    self.scripts[url] = ShellScript(url: url, name: scriptName)
+                }
             } else if resourceType == URLFileResourceType.directory {
                 let submenu = NSMenu(title: title)
                 let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -214,10 +214,10 @@ final class ScriptManager: NSObject, NSFilePresenter {
             // change behavior if modifier key is pressed
             switch NSEvent.modifierFlags() {
             case [.option]:
-                try self.editScript(at: script.url)
+                try self.editScript(at: script.descriptor.url)
                 
             case [.option, .shift]:
-                try self.revealScript(at: script.url)
+                try self.revealScript(at: script.descriptor.url)
                 
             default:
                 try script.run()

--- a/CotEditor/Sources/ScriptManager.swift
+++ b/CotEditor/Sources/ScriptManager.swift
@@ -214,10 +214,10 @@ final class ScriptManager: NSObject, NSFilePresenter {
             // change behavior if modifier key is pressed
             switch NSEvent.modifierFlags() {
             case [.option]:
-                try script.edit()
+                try self.editScript(at: script.url)
                 
             case [.option, .shift]:
-                try script.reveal()
+                try self.revealScript(at: script.url)
                 
             default:
                 try script.run()
@@ -327,6 +327,28 @@ final class ScriptManager: NSObject, NSFilePresenter {
                 self.addChildFileItem(to: submenu, in: url)
             }
         }
+    }
+    
+    /// open script file in an editor
+    /// - throws: ScriptFileError
+    private func editScript(at url: URL) throws {
+        
+        guard NSWorkspace.shared().open(url) else {
+            // display alert if cannot open/select the script file
+            throw ScriptFileError(kind: .open, url: url)
+        }
+    }
+    
+    
+    /// reveal script file in Finder
+    /// - throws: ScriptFileError
+    private func revealScript(at url: URL) throws {
+        
+        guard url.isReachable else {
+            throw ScriptFileError(kind: .existance, url: url)
+        }
+        
+        NSWorkspace.shared().activateFileViewerSelecting([url])
     }
     
     


### PR DESCRIPTION
Related #656 

The purpose of refactoring is making a clear relationship between models and a controller.

* Move user interaction (`reveal()` and `edit()`) into `ScriptManager` controller
* Add `ScriptDescriptor` as the `Script` factory, originally performed in `ScriptManager`