### PR TITLE
Update German localization

### DIFF
--- a/CotEditor/Base.lproj/EditorView.storyboard
+++ b/CotEditor/Base.lproj/EditorView.storyboard
@@ -114,8 +114,8 @@
                                 <rect key="frame" x="60" y="-1" width="16" height="17"/>
                             </progressIndicator>
                             <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Svt-vI-TEc">
-                                <rect key="frame" x="82" y="1" width="109" height="14"/>
-                                <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Extracting Outline..." id="aUE-uy-XLQ">
+                                <rect key="frame" x="82" y="1" width="107" height="14"/>
+                                <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Extracting Outline…" id="aUE-uy-XLQ">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/CotEditor/de.lproj/DocumentInspectorView.strings
+++ b/CotEditor/de.lproj/DocumentInspectorView.strings
@@ -85,4 +85,4 @@
 /* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not selected"; ObjectID = "786-4C-69e"; */
 "786-4C-69e.ibShadowedIsNilPlaceholder" = "Nicht ausgewählt";
 /* Class = "NSTextField"; ibShadowedToolTip = "Select a single character to show Unicode information."; ObjectID = "2ZU-Mi-aJz"; */
-"2ZU-Mi-aJz.ibShadowedToolTip" = "Wählen Sie ein einzelnes Zeichen aus, um Unicode-Information einzublenden";
+"2ZU-Mi-aJz.ibShadowedToolTip" = "Wähle ein einzelnes Zeichen aus, um Unicode-Information einzublenden";

--- a/CotEditor/de.lproj/EditPane.strings
+++ b/CotEditor/de.lproj/EditPane.strings
@@ -89,4 +89,4 @@
 "J1B-wA-rdr.title" = "Während der Texteingabe Vervollständigungen vorschlagen";
 
 /* Class = "NSTextFieldCell"; title = "⚠️ Select at least one item to enable completion."; ObjectID = "dmb-pc-4M5"; */
-"dmb-pc-4M5.title" = "⚠️ Wählen Sie mindestens ein Element, um die Vervollständigung zu aktivieren.";
+"dmb-pc-4M5.title" = "⚠️ Wähle mindestens ein Element, um die Vervollständigung zu aktivieren.";

--- a/CotEditor/de.lproj/EditorView.strings
+++ b/CotEditor/de.lproj/EditorView.strings
@@ -32,7 +32,7 @@
 "MlW-Dz-FOk.ibShadowedToolTip" = "Zum nächsten Gliederungspunkt springen";
 
 
-/* Class = "NSTextFieldCell"; title = "Extracting Outline..."; ObjectID = "aUE-uy-XLQ"; */
+/* Class = "NSTextFieldCell"; title = "Extracting Outline…"; ObjectID = "aUE-uy-XLQ"; */
 "aUE-uy-XLQ.title" = "Gliederung extrahieren …";
 
 

--- a/CotEditor/de.lproj/EncodingListView.strings
+++ b/CotEditor/de.lproj/EncodingListView.strings
@@ -26,7 +26,7 @@
  */
 
 /* Class = "NSTextFieldCell"; title = "Drag encodings to change the order."; ObjectID = "3395"; */
-"3395.title" = "Ziehen Sie die Codierungen, um die Reihenfolge zu ändern.";
+"3395.title" = "Ziehe die Codierungen, um die Reihenfolge zu ändern.";
 
 /* Class = "NSTextFieldCell"; title = "This list is for Auto-Detect and the file encoding menu.\nAuto-Detect tries these encodings from the top of the list."; ObjectID = "3394"; */
 "3394.title" = "Diese Liste wird für die automatische Erkennung und das Codierungsmenü verwendet.\nDie automatische Erkennung probiert die Codierungen in dieser Liste von oben beginnend durch.";

--- a/CotEditor/de.lproj/FindPanel.strings
+++ b/CotEditor/de.lproj/FindPanel.strings
@@ -33,7 +33,7 @@
 /* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Find"; ObjectID = "3sL-0v-4Cy"; */
 "3sL-0v-4Cy.ibShadowedIsNilPlaceholder" = "Suchen";
 /* Class = "NSScrollView"; ibShadowedToolTip = "Type the text to search for."; ObjectID = "hxw-DS-gxQ"; */
-"hxw-DS-gxQ.ibShadowedToolTip" = "Geben Sie den Suchbegriff ein.";
+"hxw-DS-gxQ.ibShadowedToolTip" = "Gib den Suchbegriff ein.";
 
 /* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Replace"; ObjectID = "VUA-ld-ABD"; */
 "VUA-ld-ABD.ibShadowedIsNilPlaceholder" = "Ersetzen";

--- a/CotEditor/de.lproj/FindPreferencesView.strings
+++ b/CotEditor/de.lproj/FindPreferencesView.strings
@@ -40,7 +40,7 @@
 // Textual Search
 
 /* Class = "NSTextFieldCell"; title = "Textual Search"; ObjectID = "d1L-6X-N8c"; */
-"d1L-6X-N8c.title" = "Textuelles Suche";
+"d1L-6X-N8c.title" = "Textuelle Suche";
 
 /* Class = "NSButtonCell"; title = "Distinguish characters strictly"; ObjectID = "mY4-am-wla"; */
 "mY4-am-wla.title" = "Zeichen streng unterscheiden";

--- a/CotEditor/de.lproj/IntegrationPane.strings
+++ b/CotEditor/de.lproj/IntegrationPane.strings
@@ -35,4 +35,4 @@
 "e2G-16-MxZ.ibShadowedDisplayPattern" = "bei %{value1}@ installiert";
 
 /* Class = "NSTextFieldCell"; title = "With the 'cot' command-line tool, you can launch CotEditor and let it open files from the command line."; ObjectID = "c48-xK-Ag1"; */
-"c48-xK-Ag1.title" = "Mit dem „cot“-Kommandozeilenwerkzeug können Sie CotEditor von der Kommandozeile aus aktivieren und es Dateien öffnen lassen.";
+"c48-xK-Ag1.title" = "Mit dem „cot“-Kommandozeilenwerkzeug kannst du CotEditor von der Kommandozeile aus aktivieren und es Dateien öffnen lassen.";

--- a/CotEditor/de.lproj/KeyBindingsPane.strings
+++ b/CotEditor/de.lproj/KeyBindingsPane.strings
@@ -41,7 +41,7 @@
 "Dl2-3y-7EJ.title" = "(außer Skript-Menü)";
 
 /* Class = "NSTextFieldCell"; title = "To change a binding, select it, click the key column, and then type the keys."; ObjectID = "Hue-bU-8wr"; */
-"Hue-bU-8wr.title" = "Zum Ändern eines Kurzbefehls wählen Sie ihn aus, klicken in die Taste-Spalte und drücken die Tasten.";
+"Hue-bU-8wr.title" = "Zum Ändern eines Kurzbefehls wähle ihn aus, klicke in die Taste-Spalte und drücke die Tasten.";
 
 /* Class = "NSTextFieldCell"; title = "The keys here must include the Command key."; ObjectID = "qGe-Et-FB2"; */
 "qGe-Et-FB2.title" = "Eine der Tasten muss die Command-Taste sein.";
@@ -61,22 +61,22 @@
 "eMZ-Mx-JSK.title" = "Kurzbefehle zum Einsetzen vordefinierter Texte";
 
 /* Class = "NSTextFieldCell"; title = "To change a binding, select it, click the key column, and then type the keys."; ObjectID = "a9m-M2-rgC"; */
-"a9m-M2-rgC.title" = "Zum Ändern eines Kurzbefehls wählen Sie ihn aus, klicken in die Taste-Spalte und drücken die Tasten.";
+"a9m-M2-rgC.title" = "Zum Ändern eines Kurzbefehls wähle ihn aus, klicke in die Taste-Spalte und drücke die Tasten.";
 
 /* Class = "NSTextFieldCell"; title = "The keys here must exclude the Command key."; ObjectID = "5zd-aF-0zL"; */
 "5zd-aF-0zL.title" = "Keine der Tasten darf die Command-Taste sein.";
 
 /* Class = "NSTableColumn"; headerCell.title = "Action"; ObjectID = "sz5-hl-bZK"; */
-"sz5-hl-bZK.headerCell.title" = "アクション";
+"sz5-hl-bZK.headerCell.title" = "Aktion"";
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "hXU-bV-zlt"; */
-"hXU-bV-zlt.headerCell.title" = "キー";
+"hXU-bV-zlt.headerCell.title" = "Taste";
 
 /* Class = "NSTextFieldCell"; title = "Insertion Format:"; ObjectID = "tuB-9O-QZH"; */
 "tuB-9O-QZH.title" = "Format des einzufügenden Textes:";
 /* Class = "NSMenuItem"; title = "Insert Variable"; ObjectID = "wC4-qj-3oD"; */
 "wC4-qj-3oD.title" = "Variable hinzufügen";
 /* Class = "CocoaBindingsConnection"; ibShadowedNoSelectionPlaceholder = "Select Action"; ObjectID = "Y5G-PR-ofT"; */
-"Y5G-PR-ofT.ibShadowedNoSelectionPlaceholder" = "Wählen Sie eine Aktion.";
+"Y5G-PR-ofT.ibShadowedNoSelectionPlaceholder" = "Wähle eine Aktion.";
 
 /* Class = "NSButtonCell"; title = "Restore Defaults"; ObjectID = "0Du-JI-ZN7"; */
 "0Du-JI-ZN7.title" = "Auf Standard zurücksetzen";

--- a/CotEditor/de.lproj/Localizable.strings
+++ b/CotEditor/de.lproj/Localizable.strings
@@ -50,7 +50,7 @@
 
 // Importing theme
 "“%@” is a CotEditor theme file." = "„%@“ ist eine CotEditor-Themadatei.";
-"Do you want to install this theme?" = "Möchten Sie das Thema installieren?";
+"Do you want to install this theme?" = "Möchtest du das Thema installieren?";
 "Install" = "Installieren";
 "Open as Text File" = "Als Textdatei öffnen";
 "A new theme named “%@” has been successfully installed." = "Ein neues Thema mit dem Namen „%@“ wurde erfolgreich installiert.";
@@ -71,7 +71,7 @@
 "%@ strings replaced." = "%@ Zeichenketten ersetzt.";
 "Invalid regular expression" = "Ungültiger regulärer Ausdruck";
 "Empty find string" = "Leerer Suchbegriff";
-"Input text to find." = "Geben Sie den zu findenden Text ein.";
+"Input text to find." = "Gib den zu findenden Text ein.";
 
 
 /* MARK: FindPanelController */
@@ -79,8 +79,8 @@
 "Replace the current selection with the replacement text." = "Die aktuelle Auswahl durch den Ersetzungstext ersetzen.";
 "Not Found" = "Nicht gefunden";
 "%@ found" = "%@ gefunden";  // %@ is number of founds
-"Not Replaced" = "見つかりません";
-"%@ replaced" = "%@ 件置換しました";  // %@ is number of replaced
+"Not Replaced" = "Nicht ersetzt";
+"%@ replaced" = "%@ ersetzt";  // %@ is number of replaced
 
 
 /* MARK: FindPanelResultViewController */
@@ -97,11 +97,11 @@
 
 // Binary file alert
 "The file “%@” doesn’t appear to be text data." = "Die Datei „%@” entspricht keiner Textdatei.";
-"The file is %@.\n\nDo you really want to open the file?" = "Die Datei ist %@.\n\nMöchten Sie die Datei wirklich öffnen?";
+"The file is %@.\n\nDo you really want to open the file?" = "Die Datei ist %@.\n\nMöchtest du die Datei wirklich öffnen?";
 
 // Large file alert
 "The file “%@” has a size of %@." = "Die Datei „%@“ hat eine Größe von %@.";
-"Opening such a large file can make the application slow or unresponsive.\n\nDo you really want to open the file?" = "Wenn eine so große Datei geöffnet wird, kann das Programm langsam werden oder nicht mehr reagieren.\n\nMöchten Sie die Datei wirklich öffnen?";
+"Opening such a large file can make the application slow or unresponsive.\n\nDo you really want to open the file?" = "Wenn eine so große Datei geöffnet wird, kann das Programm langsam werden oder nicht mehr reagieren.\n\nMöchtest du die Datei wirklich öffnen?";
 "Open" = "Öffnen";
 
 
@@ -113,41 +113,41 @@
 
 // Convert or reinterpret encoding alert
 "File encoding" = "Dateicodierung";
-"Do you want to convert or reinterpret this document using “%@”?" = "Möchten Sie dieses Dokument mit „%@“ umwandeln oder neu interpretieren?";
+"Do you want to convert or reinterpret this document using “%@”?" = "Möchtest du dieses Dokument mit „%@“ umwandeln oder neu interpretieren?";
 "Convert" = "Umwandeln";
 "Reinterpret" = "Neu interpretieren";
 
 // Lossy encoding alert
 "Some characters would have to be changed or deleted in saving as “%@”." = "Beim Speichern in „%@“ müssen einige Zeichen möglicherweise geändert oder gelöscht werden.";
-"Do you want to continue processing?" = "Möchten Sie mit der Bearbeitung fortfahren?";
+"Do you want to continue processing?" = "Möchtest du mit der Bearbeitung fortfahren?";
 "Save Available Strings" = " Verfügbare Zeichenkette speichern";
 "Show Incompatible Characters" = "Inkompatible Zeichen einblenden";
 
 // Incompatible IANA charset name alert
 "The encoding is “%@”, but the IANA charset name in text is “%@”." = "Die Codierung ist „%@“, doch der IANA-Zeichensatzname ist „%@“.";
-"Do you want to continue processing?" = "Möchten Sie mit der Bearbeitung fortfahren?";
+"Do you want to continue processing?" = "Möchtest du mit der Bearbeitung fortfahren?";
 "Do not show this warning for this document again" = "Diese Warnung für dieses Dokument nicht erneut anzeigen";
 "Continue Saving" = "Speicherung fortsetzen";
 
 // Encoding change with unsaved changes alert
 "The file “%@” has unsaved changes." = "Die Datei „%@“ hat ungespeicherte Änderungen.";
-"Do you want to discard the changes and reset the file encoding?" = "Möchten Sie die Änderungen verwerfen und die Dateicodierung zurücksetzen?";
+"Do you want to discard the changes and reset the file encoding?" = "Möchtest du die Änderungen verwerfen und die Dateicodierung zurücksetzen?";
 "Discard Changes" = "Änderungen verwerfen";
 
 // Reinterpretation failed alert
 "The document doesn’t have a file to reinterpret." = "Das Dokument hat keine Datei zum Neuinterpretieren.";
 "The file “%@” couldn’t be reinterpreted using text encoding “%@”." = "Die Datei „%@“ konnte nicht mithilfe der Codierung „%@“ neu interpretiert werden.";
-"The file may have been saved using a different text encoding, or it may not be a text file." = "Die Datei wurde möglicherweise mit einer anderen Textcodierung gesichert order es handelt sich nicht um eine Textdatei";
+"The file may have been saved using a different text encoding, or it may not be a text file." = "Die Datei wurde möglicherweise mit einer anderen Textcodierung gesichert oder es handelt sich nicht um eine Textdatei.";
 
 // incompatible characters alert
 "Some characters would have to be changed or deleted in saving as “%@”." = "Beim Speichern in „%@“ müssen einige Zeichen möglicherweise geändert oder gelöscht werden.";
-"Do you want to change encoding and show incompatible characters?" = "Möchten Sie die Codierung ändern und die inkompatiblen Zeichen zeigen?";
+"Do you want to change encoding and show incompatible characters?" = "Möchtest du die Codierung ändern und die inkompatiblen Zeichen zeigen?";
 "Change Encoding" = "Codierung wechseln";
 
 // Modified by an external application alert
 "The file has been modified by another application. There are also unsaved changes in CotEditor." = "Die Datei wurde durch ein anderes Programm geändert. Es gibt auch ungespeicherte Änderungen in CotEditor.";
 "The file has been modified by another application." = "Die Datei wurde durch ein anderes Programm geändert.";
-"Do you want to keep CotEditor’s edition or update to the modified edition?" = "Möchten Sie CotEditors Version behalten oder auf die geänderte Version aktualisieren?";
+"Do you want to keep CotEditor’s edition or update to the modified edition?" = "Möchtest du CotEditors Version behalten oder auf die geänderte Version aktualisieren?";
 "Keep CotEditor’s Edition" = "CotEditors Version behalten";
 "Update" = "Aktualisieren";
 
@@ -271,7 +271,7 @@
 
 // Tooltip for "Show Invisible Characters" menu item
 "Show or hide invisible characters in document" = "Unsichtbare Zeichen im Text ein-/ausblenden";
-"To show invisible characters, set them in Preferences" = "Um unsichtbare Zeichen anzuzeigen, setzen Sie sie in den Einstellungen";
+"To show invisible characters, set them in Preferences" = "Um unsichtbare Zeichen anzuzeigen, setze sie in den Einstellungen";
 
 
 
@@ -332,7 +332,7 @@
 // General pane
 // Autosave setting update alert
 "The change will be applied first at the next launch." = "Die Änderung wird erst beim nächsten Start angewendet.";
-"Do you want to restart CotEditor now?" = "Möchten Sie CotEditor jetzt neu starten?";
+"Do you want to restart CotEditor now?" = "Möchtest du CotEditor jetzt neu starten?";
 "Restart Now" = "Neu starten";
 "Later" = "Später";
 
@@ -344,7 +344,7 @@
 "Restore “%@”" = "„%@“ zurücksetzen";
 "Reveal “%@” in Finder" = "„%@“ im Finder anzeigen";
 // Theme delete alert
-"Are you sure you want to delete “%@” theme?" = "Möchten Sie das Thema „%@“ wirklich löschen?";
+"Are you sure you want to delete “%@” theme?" = "Möchtest du das Thema „%@“ wirklich löschen?";
 "This action cannot be undone." = "Diese Aktion kann nicht widerrufen werden.";
 
 // Swipe to delete (also used in the Format pane)
@@ -354,7 +354,7 @@
 
 // Format pane
 // Encoding menu alert
-"Are you sure you want to change to “%@”?" = "Möchten Sie wirklich zu „%@“ wechseln?";
+"Are you sure you want to change to “%@”?" = "Möchtest du wirklich zu „%@“ wechseln?";
 "The default “Auto-Detect” is recommended for most cases." = "Die automatische Erkennung wird für die meisten Fälle empfohlen.";
 "Change to “%@”" = "Zu „%@“ wechseln";
 "Revert to “Auto-Detect”" = "Auf „Autom. erkennen“ zurücksetzen";
@@ -367,7 +367,7 @@
 
 // File Drop pane
 // File drop setting deletion alert
-"Are you sure you want to delete the file drop setting for “%@”?" = "Möchten Sie die Einstellung von Datei-Drop für „%@“ wirklich löschen?";
+"Are you sure you want to delete the file drop setting for “%@”?" = "Möchtest du die Einstellung von Datei-Drop für „%@“ wirklich löschen?";
 "Deleted setting can’t be restored." = "Gelöschte Einstellung kann nicht wiederhergestellt werden.";
 
 
@@ -413,7 +413,7 @@
 "No original file for “%@” was found." = "Keine Original-Datei für „%@“ wurde gefunden.";
 
 // Setting file name warnings
-"Please choose another name." = "Bitte wählen Sie einen anderen Namen.";
+"Please choose another name." = "Bitte wähle einen anderen Namen.";
 "Name can’t be empty." = "Name darf nicht leer sein.";
 "You can’t use a name that contains “/”." = "Name darf kein „/“ enthalten.";
 "You can’t use a name that begins with a dot “.”." = "Name darf nicht mit einem Punkt „.“ beginnen.";
@@ -432,7 +432,7 @@
 "copy" = "Kopie";
 
 // Delete syntax style alert
-"Are you sure you want to delete “%@” syntax style?" = "Möchten Sie den Syntaxstil „%@“ wirklich löschen?";
+"Are you sure you want to delete “%@” syntax style?" = "Möchtest du den Syntaxstil „%@“ wirklich löschen?";
 "This action cannot be undone." = "Diese Aktion kann nicht widerrufen werden.";
 "Delete" = "Löschen";
 "Replace" = "Ersetzen";
@@ -441,7 +441,7 @@
 "Import" = "Importieren";
 // Importing same name style alert
 "A new style named “%@” will be installed, but a custom style with the same name already exists." = "Ein neuer Stil mit dem Namen „%@“ wird installiert, doch ein benutzerdefinierter Stil mit demselben Namen existiert bereits.";
-"Do you want to replace it?\nReplaced style can’t be restored." = "Möchten Sie ihn ersetzen?\nErsetzter Stil kann nicht wiederhergestellt werden.";
+"Do you want to replace it?\nReplaced style can’t be restored." = "Möchtest du ihn ersetzen?\nErsetzter Stil kann nicht wiederhergestellt werden.";
 
 // Export syntax style file savePanel label
 "Export As:" = "Exportieren als:";
@@ -463,7 +463,7 @@
 
 // Theme import duplicated alert
 "A new theme named “%@” will be installed, but a custom theme with the same name already exists." = "Ein neues Thema mit dem Namen „%@“ wird installiert, doch ein benutzerdefiniertes Thema mit dem selben Namen existiert bereits.";
-"Do you want to replace it?\nReplaced theme can’t be restored." = "Möchten Sie es ersetzen?\nErsetztes Thema kann nicht wiederhergestellt werden.";
+"Do you want to replace it?\nReplaced theme can’t be restored." = "Möchtest du es ersetzen?\nErsetztes Thema kann nicht wiederhergestellt werden.";
 
 
 
@@ -478,9 +478,9 @@
 "“%@” is already taken." = "„%@“ wird bereits verwendet.";
 "“%@” does not include the Command key." = "„%@“ enthält nicht die Command-Taste.";
 "“%@” includes the Command key." = "„%@“ enthält die Command-Taste.";
-"Please choose another key." = "Bitte wählen Sie eine andere Taste.";
+"Please choose another key." = "Bitte wähle eine andere Taste.";
 "Single type is invalid for a shortcut." = "Einzelne Tasten sind für einen Kurzbefehl ungültig.";
-"Please combine with another keys." = "Bitte kombinieren Sie sie mit anderen Tasten.";
+"Please combine with another keys." = "Bitte kombiniere sie mit anderen Tasten.";
 
 
 
@@ -502,12 +502,12 @@
 // Script file error description
 "The script “%@” does not exist." = "Das Skript „%@“ existiert nicht.";
 "The script file “%@” couldn’t be opened." = "Die Skriptdatei „%@“ konnte nicht geöffnet werden.";
-"The script “%@” can’t be executed because you don’t have the execute permission." = "Das Skript „%@“ kann nicht ausgeführt werden, da Sie keine Ausführungsrechte haben.";
+"The script “%@” can’t be executed because you don’t have the execute permission." = "Das Skript „%@“ kann nicht ausgeführt werden, da du keine Ausführungsrechte hast.";
 "The script “%@” couldn’t be read." = "Das Skript „%@“ konnte nicht gelesen werden.";
 
 // Script file error recovery suggestions
-"Check the script file." = "Prüfen Sie die Skriptdatei.";
-"Check permission of the script file." = "Prüfen Sie die Zugriffsrechte der Skriptdatei.";
+"Check the script file." = "Prüfe die Skriptdatei.";
+"Check permission of the script file." = "Prüfe die Zugriffsrechte der Skriptdatei.";
 
 
 

--- a/CotEditor/de.lproj/Main.strings
+++ b/CotEditor/de.lproj/Main.strings
@@ -464,7 +464,7 @@
 "PWZ-Om-OhX.title" = "Nächsten Gliederungspunkt auswählen";
 
 /* Class = "NSMenuItem"; title = "Go to Line…"; ObjectID = "eIc-Sj-2mO"; */
-"eIc-Sj-2mO.title" = "Gehe zu Zeile…";
+"eIc-Sj-2mO.title" = "Gehe zu Zeile …";
 
 
 

--- a/CotEditor/de.lproj/ReportTemplate.md
+++ b/CotEditor/de.lproj/ReportTemplate.md
@@ -1,5 +1,5 @@
 
-Füllen Sie die folgende Vorlage aus und posten Sie sie auf [GitHub Issues](https://github.com/coteditor/CotEditor/issues) oder senden Sie sie uns an <coteditor.github@gmail.com>. Bitte beachten Sie, dass der Inhalt der gesendeten E-Mail auf einer Issue-Seite geteilt werden könnte.
+Fülle die folgende Vorlage aus und poste sie auf [GitHub Issues](https://github.com/coteditor/CotEditor/issues) oder sende sie uns an <coteditor.github@gmail.com>. Bitte beachte, dass der Inhalt der gesendeten E-Mail auf einer Issue-Seite geteilt werden könnte.
 
 -----------------------------------------------
 
@@ -12,14 +12,14 @@ Füllen Sie die folgende Vorlage aus und posten Sie sie auf [GitHub Issues](http
 
 ## Short Description (Kurzbeschreibung)
 
-<!-- Schreiben Sie hier Ihren Kommentar -->
+<!-- Schreibe hier deinen Kommentar -->
 
 
 ## Steps to Reproduce the Issue (Schritte zur Reproduktion)
 
-<!-- Schreiben Sie hier Ihren Kommentar -->
+<!-- Schreibe hier deinen Kommentar -->
 
 
 ## Expected Result (Erwartetes Ergebnis)
 
-<!-- Schreiben Sie hier Ihren Kommentar -->
+<!-- Schreibe hier deinen Kommentar -->

--- a/CotEditor/de.lproj/SizeSettingWindow.strings
+++ b/CotEditor/de.lproj/SizeSettingWindow.strings
@@ -29,7 +29,7 @@
 "127.title" = "Standardgröße-Probefenster";
 
 /* Class = "NSTextFieldCell"; title = "Resize this window.\nThe size of this window will be set as default."; ObjectID = "3399"; */
-"3399.title" = "Ändern Sie die Größe dieses Fensters.\nSie wird als Standardgröße festgelegt werden.";
+"3399.title" = "Ändere die Größe dieses Fensters.\nSie wird als Standardgröße festgelegt werden.";
 
 /* Class = "NSTextFieldCell"; title = "Width:"; ObjectID = "3402"; */
 "3402.title" = "Breite:";

--- a/CotEditor/de.lproj/SyntaxMappingConflictView.strings
+++ b/CotEditor/de.lproj/SyntaxMappingConflictView.strings
@@ -29,7 +29,7 @@
 "1022.title" = "Dateizuordnungskonflikte";
 
 /* Class = "NSTextFieldCell"; title = "CotEditor uses the first style automatically. To resolve conflicts, edit each syntax style."; ObjectID = "gnp-H7-p1W"; */
-"gnp-H7-p1W.title" = "CotEditor verwendet den ersten Stil automatisch. Um Konflikte zu beheben, bearbeiten Sie jeden Syntaxstil.";
+"gnp-H7-p1W.title" = "CotEditor verwendet den ersten Stil automatisch. Um Konflikte zu beheben, bearbeite jeden Syntaxstil.";
 
 
 /* Class = "NSTextFieldCell"; title = "Extension:"; ObjectID = "31z-NP-PkW"; */

--- a/CotEditor/it.lproj/EditorView.strings
+++ b/CotEditor/it.lproj/EditorView.strings
@@ -33,7 +33,7 @@
 "MlW-Dz-FOk.ibShadowedToolTip" = "Salta all’elemento Outline precedente";
 
 
-/* Class = "NSTextFieldCell"; title = "Extracting Outline..."; ObjectID = "aUE-uy-XLQ"; */
+/* Class = "NSTextFieldCell"; title = "Extracting Outline…"; ObjectID = "aUE-uy-XLQ"; */
 "aUE-uy-XLQ.title" = "Estrazione Outline…";
 
 

--- a/CotEditor/ja.lproj/EditorView.strings
+++ b/CotEditor/ja.lproj/EditorView.strings
@@ -32,7 +32,7 @@
 "MlW-Dz-FOk.ibShadowedToolTip" = "次の項目へ";
 
 
-/* Class = "NSTextFieldCell"; title = "Extracting Outline..."; ObjectID = "aUE-uy-XLQ"; */
+/* Class = "NSTextFieldCell"; title = "Extracting Outline…"; ObjectID = "aUE-uy-XLQ"; */
 "aUE-uy-XLQ.title" = "アウトラインを抽出中...";
 
 

--- a/CotEditor/zh-Hans.lproj/EditorView.strings
+++ b/CotEditor/zh-Hans.lproj/EditorView.strings
@@ -33,7 +33,7 @@
 "MlW-Dz-FOk.ibShadowedToolTip" = "下一个提纲项目";
 
 
-/* Class = "NSTextFieldCell"; title = "Extracting Outline..."; ObjectID = "aUE-uy-XLQ"; */
+/* Class = "NSTextFieldCell"; title = "Extracting Outline…"; ObjectID = "aUE-uy-XLQ"; */
 "aUE-uy-XLQ.title" = "提取提纲…";
 
 


### PR DESCRIPTION
Apart from a few fixes, I changed all previously formal strings to informal, since thats how macOS addresses the user starting with Sierra.

Edit: I just noticed I added an unnecessary quotation mark in line 70 of KeyBindingsPane.strings. Doesn't break anything though. Sorry.