### PR TITLE
Update build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ CotEditor is a pure document-based Cocoa application written in Swift.
 How to Build
 -----------------------------
 
-1. Open CotEditor.xcworkspace in Xcode.
-2. build.
+1. `git submodule update --init`
+2. Open CotEditor.xcworkspace in Xcode.
+3. build.
 
 
 


### PR DESCRIPTION
Without submodule `cot`, Xcode will throw an PBXCp Error: `CotEditor/cot/cot: No such file or directory`.

So I add this to build instruction.

`git submodule update --init`