### PR TITLE
Fix findAll() of TextFind

### DIFF
--- a/CotEditor/Sources/TextFind.swift
+++ b/CotEditor/Sources/TextFind.swift
@@ -221,9 +221,10 @@ final class TextFind {
             
             var matches = [matchedRange]
             
-            guard let match = match else { return }
-            if numberOfGroups > 0 {
-                matches += (1...numberOfGroups).map { match.range(at: $0) }
+            if let match = match {
+                if numberOfGroups > 0 {
+                    matches += (1...numberOfGroups).map { match.range(at: $0) }
+                }
             }
             
             block(matches, &stop)

--- a/CotEditor/Sources/TextFind.swift
+++ b/CotEditor/Sources/TextFind.swift
@@ -221,7 +221,8 @@ final class TextFind {
             
             var matches = [matchedRange]
             
-            if let match = match {
+            guard let match = match else { return }
+            if numberOfGroups > 0 {
                 matches += (1...numberOfGroups).map { match.range(at: $0) }
             }
             

--- a/Tests/TextFindTests.swift
+++ b/Tests/TextFindTests.swift
@@ -191,6 +191,19 @@ class TextFindTests: XCTestCase {
         XCTAssertEqual(matches[1].count, 2)
         XCTAssertEqual(matches[1][0], NSRange(location: 9, length: 2))
         XCTAssertEqual(matches[1][1], NSRange(location: 10, length: 1))
+        
+        
+        textFind = try! TextFind(for: "abcdefg ABCDEFG", findString: "ab", settings: settings)
+        
+        matches = [[NSRange]]()
+        textFind.findAll { (matchedRanges, stop) in
+            matches.append(matchedRanges)
+        }
+        XCTAssertEqual(matches.count, 2)
+        XCTAssertEqual(matches[0].count, 1)
+        XCTAssertEqual(matches[0][0], NSRange(location: 0, length: 2))
+        XCTAssertEqual(matches[1].count, 1)
+        XCTAssertEqual(matches[1][0], NSRange(location: 8, length: 2))
     }
     
     


### PR DESCRIPTION
I tried finding and replacement using regex in CotEditor. I inputted a regular expression which has no groups and click "Find All" as shown in the following the image. Then, CotEditor crashed.

![coteditor_report](https://user-images.githubusercontent.com/17570265/36072795-82fcb02c-0f69-11e8-9676-e63032cd5b61.jpg)

So I add support for case that regular expression has no groups in findAll() of TextFind.

My environment : 

* CotEditor 3.3.0 (224)
* macOS High Sierra 10.13.3