### PR TITLE
Correcting Date Formatter Strings

### DIFF
--- a/CotEditor/Sources/Console.swift
+++ b/CotEditor/Sources/Console.swift
@@ -102,7 +102,7 @@ final class ConsoleViewController: NSViewController {
     
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYYY-MM-dd HH:mm:ss"
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         return formatter
     }()
     

--- a/CotEditor/Sources/DefaultSettings.swift
+++ b/CotEditor/Sources/DefaultSettings.swift
@@ -175,7 +175,7 @@ struct DefaultSettings {
         .selectedInspectorPaneIndex: 0,
         
         // ------ hidden settings ------
-        .headerFooterDateFormat: "YYYY-MM-dd HH:mm",
+        .headerFooterDateFormat: "yyyy-MM-dd HH:mm",
         .headerFooterPathAbbreviatingWithTilde: true,
         .autoCompletionDelay: 0.25,
         .showColoringIndicatorTextLength: 75000,


### PR DESCRIPTION
As explained by NSHipster :

"YYYY" is the format for the ISO week-numbering year, which returns 2020 for December 31st, 2019 because the following day is a Wednesday in the first week of the new year.

What we actually want is "yyyy".