### PR TITLE
Improve TOML syntax style to support array of tables

### DIFF
--- a/CotEditor/Syntaxes/TOML.yaml
+++ b/CotEditor/Syntaxes/TOML.yaml
@@ -3,15 +3,18 @@ extensions:
 filenames: []
 interpreters: []
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   author: "1024jp"
   license: "Same as CotEditor"
-  lastModified: "2018-12-05"
+  lastModified: "2019-07-16"
   distributionURL: "https://coteditor.com"
 commentDelimiters:
   inlineDelimiter: "#"
 keywords:
-- beginString: "(?<=\\[)[^\\],]+(?=\\])"
+- beginString: "(?<=\\[\\[)[^\\],]+(?=\\]\\])"
+  description: "array of tables"
+  regularExpression: true
+- beginString: "(?<!\\[\\[)(?<=\\[)[^\\],]+(?=\\])(?!\\]\\])"
   description: "table"
   regularExpression: true
 attributes: []


### PR DESCRIPTION
The TOML syntax style in CotEditor didn't support [array of tables](https://github.com/toml-lang/toml#array-of-tables), so I updated the syntax style to support it.

![TOML in CotEditor](https://user-images.githubusercontent.com/9448125/61284079-333f6a00-a7f9-11e9-9585-6d6a819066ff.png)

I tested the syntax style with [sample TOML files](https://github.com/toml-lang/toml/tree/master/tests) provided by the TOML project. The previous syntax highlighting works fine except arrays of tables, and the updated version which I'm sending works fine for everything :smile: