### PR TITLE
Add `README.md` to Xcode workspace.

### DIFF
--- a/CotEditor.xcworkspace/contents.xcworkspacedata
+++ b/CotEditor.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:README.md">
+   </FileRef>
+   <FileRef
       location = "group:CHANGELOG.md">
    </FileRef>
    <FileRef


### PR DESCRIPTION
**Problem**

Xcode.app automatically opens first `README.md` found in the workspace
when it opens first time.

Currently it is the one of SPM's README.md, which confuses the
developer who opens workspace first time.

**Solution**

Add CotEditor's `README.md` at the top of the workspace tree.