### PR TITLE
Prevented the background of the Acknowledgments window from flashing when in dark mode.

### DIFF
--- a/CotEditor/Sources/WebDocumentViewController.swift
+++ b/CotEditor/Sources/WebDocumentViewController.swift
@@ -51,6 +51,8 @@ final class WebDocumentViewController: NSViewController {
 
             self.webView?.configuration.userContentController.addUserScript(script)
         #endif
+
+        self.webView?.setValue(false, forKey: "drawsBackground")
     }
     
     


### PR DESCRIPTION
There was a problem with the background flashing when opening the Acknowledgments.

![flashing](https://user-images.githubusercontent.com/19896354/101882507-59795d00-3bd9-11eb-8da7-822409825b6f.gif)
