### PR TITLE
Added max to line counter to ensure line position is >= 1

### DIFF
--- a/CotEditor/Sources/EditorInfoCounter.swift
+++ b/CotEditor/Sources/EditorInfoCounter.swift
@@ -225,7 +225,7 @@ final class EditorInfoCounter {
         try Task.checkCancellation()
         
         if self.requiredInfo.contains(.line) {
-            cursor.line = string.numberOfLines
+            cursor.line = max(string.numberOfLines, 1)
         }
         
         try Task.checkCancellation()


### PR DESCRIPTION
Fixes #1239

I can reproduce this issue:

https://user-images.githubusercontent.com/6761721/151638735-a4b99de2-4edb-413a-be73-f29ccdb7387a.mov

The line position of the cursor appears 0 when located at line 1 column 1. This is because `string.numberOfLines` returns 0 if the string is empty. Adding a max function to this ensures the count will never return 0.

After fix:

https://user-images.githubusercontent.com/6761721/151638755-53a74786-caef-4fd3-92b0-8305730a0e48.mov