### PR TITLE
Temporarily highlight current term in the textView on search.

### DIFF
--- a/CotEditor/Sources/TextFinder.swift
+++ b/CotEditor/Sources/TextFinder.swift
@@ -433,6 +433,7 @@ final class TextFinder: NSResponder, NSMenuItemValidation {
         // found feedback
         if let range = result.range {
             textView.select(range: range)
+            textView.showFindIndicator(for: range)
             
             if result.wrapped {
                 if let view = textView.enclosingScrollView?.superview {


### PR DESCRIPTION
This PR uses `-[NSTextView showFindIndicatorForRange:]` to temporarily highlight current term in the textView on search.

https://user-images.githubusercontent.com/8158163/160272224-24a1d0a4-ca2f-4fa1-874d-18514a3a464d.mov
