### PR TITLE
zh-Hant localization.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 
 ## Xcode
+[Bb]uild
 xcuserdata/
 *.xccheckout
 *.xcscmblueprint

--- a/CotEditor.xcodeproj/project.pbxproj
+++ b/CotEditor.xcodeproj/project.pbxproj
@@ -1506,6 +1506,49 @@
 		57ED31751FFD892900F16CAD /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = pt; path = pt.lproj/Credits.html; sourceTree = "<group>"; };
 		57ED31761FFD892900F16CAD /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = pt; path = pt.lproj/Acknowledgments.html; sourceTree = "<group>"; };
 		57ED31771FFD892A00F16CAD /* pt */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = pt; path = pt.lproj/ReportTemplate.md; sourceTree = "<group>"; };
+		5B0884E828296B5F003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Main.strings"; sourceTree = "<group>"; };
+		5B0884E928296B5F003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/PreferencesWindow.strings"; sourceTree = "<group>"; };
+		5B0884EA28296B5F003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/GeneralPane.strings"; sourceTree = "<group>"; };
+		5B0884EB28296B5F003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/WindowPane.strings"; sourceTree = "<group>"; };
+		5B0884EC28296B5F003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/AppearancePane.strings"; sourceTree = "<group>"; };
+		5B0884ED28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/EditPane.strings"; sourceTree = "<group>"; };
+		5B0884EE28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/FormatPane.strings"; sourceTree = "<group>"; };
+		5B0884EF28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/FileDropPane.strings"; sourceTree = "<group>"; };
+		5B0884F028296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/KeyBindingsPane.strings"; sourceTree = "<group>"; };
+		5B0884F128296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/PrintPane.strings"; sourceTree = "<group>"; };
+		5B0884F228296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxEditView.strings"; sourceTree = "<group>"; };
+		5B0884F328296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxTermsEditView.strings"; sourceTree = "<group>"; };
+		5B0884F428296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxCommentsEditView.strings"; sourceTree = "<group>"; };
+		5B0884F528296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxOutlineEditView.strings"; sourceTree = "<group>"; };
+		5B0884F628296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxCompletionsEditView.strings"; sourceTree = "<group>"; };
+		5B0884F728296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxFileMappingEditView.strings"; sourceTree = "<group>"; };
+		5B0884F828296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxInfoEditView.strings"; sourceTree = "<group>"; };
+		5B0884F928296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/EncodingListView.strings"; sourceTree = "<group>"; };
+		5B0884FA28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SyntaxMappingConflictsView.strings"; sourceTree = "<group>"; };
+		5B0884FB28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/FindPanel.strings"; sourceTree = "<group>"; };
+		5B0884FC28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/FindPreferencesView.strings"; sourceTree = "<group>"; };
+		5B0884FD28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MultipleReplacementPanel.strings"; sourceTree = "<group>"; };
+		5B0884FE28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/DocumentWindow.strings"; sourceTree = "<group>"; };
+		5B0884FF28296B60003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/DocumentInspectorView.strings"; sourceTree = "<group>"; };
+		5B08850028296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/OutlineView.strings"; sourceTree = "<group>"; };
+		5B08850128296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/WarningsView.strings"; sourceTree = "<group>"; };
+		5B08850228296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/EditorView.strings"; sourceTree = "<group>"; };
+		5B08850328296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/OpenDocumentAccessory.strings"; sourceTree = "<group>"; };
+		5B08850428296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/SaveDocumentAccessory.strings"; sourceTree = "<group>"; };
+		5B08850528296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/PrintPanelAccessory.strings"; sourceTree = "<group>"; };
+		5B08850628296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/ProgressView.strings"; sourceTree = "<group>"; };
+		5B08850728296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/CompactProgressView.strings"; sourceTree = "<group>"; };
+		5B08850828296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/GoToLineView.strings"; sourceTree = "<group>"; };
+		5B08850928296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/PatternSortView.strings"; sourceTree = "<group>"; };
+		5B08850A28296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/CustomSurroundStringView.strings"; sourceTree = "<group>"; };
+		5B08850B28296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/CustomTabWidthView.strings"; sourceTree = "<group>"; };
+		5B08850C28296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/CharacterPopover.strings"; sourceTree = "<group>"; };
+		5B08850D28296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/UnicodeInputView.strings"; sourceTree = "<group>"; };
+		5B08850E28296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/ConsolePanel.strings"; sourceTree = "<group>"; };
+		5B08850F28296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/ColorCodePanelAccessory.strings"; sourceTree = "<group>"; };
+		5B08851028296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "zh-Hant"; path = "zh-Hant.lproj/Credits.html"; sourceTree = "<group>"; };
+		5B08851128296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "zh-Hant"; path = "zh-Hant.lproj/Acknowledgments.html"; sourceTree = "<group>"; };
+		5B08851228296B61003D4C2D /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = "zh-Hant"; path = "zh-Hant.lproj/ReportTemplate.md"; sourceTree = "<group>"; };
 		6C1E212412C9E65600194313 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		8D15AC360486D014006FF6A4 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D15AC370486D014006FF6A4 /* CotEditor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CotEditor.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2655,6 +2698,7 @@
 				fr,
 				tr,
 				"en-GB",
+				"zh-Hant",
 			);
 			mainGroup = 2A37F4AAFDCFA73011CA2CEA /* CotEditor */;
 			packageReferences = (
@@ -3575,6 +3619,7 @@
 				0D51D57B2274EADF00A5D747 /* fr */,
 				08C28F83279CBE2D0016693E /* tr */,
 				98EAE81427A5D7D700C6D571 /* en-GB */,
+				5B0884EB28296B5F003D4C2D /* zh-Hant */,
 			);
 			name = WindowPane.storyboard;
 			sourceTree = "<group>";
@@ -3591,6 +3636,7 @@
 				0D51D5802274EAE100A5D747 /* fr */,
 				08C28F88279CBE2D0016693E /* tr */,
 				98EAE81927A5D7D700C6D571 /* en-GB */,
+				5B0884F028296B60003D4C2D /* zh-Hant */,
 			);
 			name = KeyBindingsPane.storyboard;
 			sourceTree = "<group>";
@@ -3607,6 +3653,7 @@
 				0D51D5812274EAE100A5D747 /* fr */,
 				08C28F89279CBE2D0016693E /* tr */,
 				98EAE81A27A5D7D700C6D571 /* en-GB */,
+				5B0884F128296B60003D4C2D /* zh-Hant */,
 			);
 			name = PrintPane.storyboard;
 			sourceTree = "<group>";
@@ -3623,6 +3670,7 @@
 				0D51D57C2274EADF00A5D747 /* fr */,
 				08C28F84279CBE2D0016693E /* tr */,
 				98EAE81527A5D7D700C6D571 /* en-GB */,
+				5B0884EC28296B5F003D4C2D /* zh-Hant */,
 			);
 			name = AppearancePane.storyboard;
 			sourceTree = "<group>";
@@ -3639,6 +3687,7 @@
 				0D51D57D2274EAE000A5D747 /* fr */,
 				08C28F85279CBE2D0016693E /* tr */,
 				98EAE81627A5D7D700C6D571 /* en-GB */,
+				5B0884ED28296B60003D4C2D /* zh-Hant */,
 			);
 			name = EditPane.storyboard;
 			sourceTree = "<group>";
@@ -3655,6 +3704,7 @@
 				0D51D57E2274EAE000A5D747 /* fr */,
 				08C28F86279CBE2D0016693E /* tr */,
 				98EAE81727A5D7D700C6D571 /* en-GB */,
+				5B0884EE28296B60003D4C2D /* zh-Hant */,
 			);
 			name = FormatPane.storyboard;
 			sourceTree = "<group>";
@@ -3671,6 +3721,7 @@
 				0D51D5762274EADC00A5D747 /* fr */,
 				08C28FA2279CBE2F0016693E /* tr */,
 				98EAE83327A5D7DA00C6D571 /* en-GB */,
+				5B08850928296B61003D4C2D /* zh-Hant */,
 			);
 			name = PatternSortView.storyboard;
 			sourceTree = "<group>";
@@ -3687,6 +3738,7 @@
 				0D51D5782274EADD00A5D747 /* fr */,
 				08C28FA4279CBE2F0016693E /* tr */,
 				98EAE83527A5D7DA00C6D571 /* en-GB */,
+				5B08850B28296B61003D4C2D /* zh-Hant */,
 			);
 			name = CustomTabWidthView.storyboard;
 			sourceTree = "<group>";
@@ -3703,6 +3755,7 @@
 				0D51D56B2274EAD600A5D747 /* fr */,
 				08C28F96279CBE2E0016693E /* tr */,
 				98EAE82727A5D7D900C6D571 /* en-GB */,
+				5B0884FD28296B60003D4C2D /* zh-Hant */,
 			);
 			name = MultipleReplacementPanel.storyboard;
 			sourceTree = "<group>";
@@ -3719,6 +3772,7 @@
 				0D51D56F2274EAD800A5D747 /* fr */,
 				08C28F9A279CBE2F0016693E /* tr */,
 				98EAE82B27A5D7D900C6D571 /* en-GB */,
+				5B08850128296B61003D4C2D /* zh-Hant */,
 			);
 			name = WarningsView.storyboard;
 			sourceTree = "<group>";
@@ -3735,6 +3789,7 @@
 				0D51D56D2274EAD700A5D747 /* fr */,
 				08C28F98279CBE2F0016693E /* tr */,
 				98EAE82927A5D7D900C6D571 /* en-GB */,
+				5B0884FF28296B60003D4C2D /* zh-Hant */,
 			);
 			name = DocumentInspectorView.storyboard;
 			sourceTree = "<group>";
@@ -3751,6 +3806,7 @@
 				0D51D5792274EADD00A5D747 /* fr */,
 				08C28F81279CBE2C0016693E /* tr */,
 				98EAE81227A5D7D600C6D571 /* en-GB */,
+				5B0884E928296B5F003D4C2D /* zh-Hant */,
 			);
 			name = PreferencesWindow.storyboard;
 			sourceTree = "<group>";
@@ -3767,6 +3823,7 @@
 				2A5DD44122793B9B0057AAD1 /* fr */,
 				08C28FAC279CBE300016693E /* tr */,
 				98EAE83D27A5D7DA00C6D571 /* en-GB */,
+				5B08851228296B61003D4C2D /* zh-Hant */,
 			);
 			name = ReportTemplate.md;
 			sourceTree = "<group>";
@@ -3783,6 +3840,7 @@
 				0D51D5682274EAD400A5D747 /* fr */,
 				08C28F94279CBE2E0016693E /* tr */,
 				98EAE82527A5D7D900C6D571 /* en-GB */,
+				5B0884FB28296B60003D4C2D /* zh-Hant */,
 			);
 			name = FindPanel.storyboard;
 			sourceTree = "<group>";
@@ -3814,6 +3872,7 @@
 				0D51D5702274EAD800A5D747 /* fr */,
 				08C28F9B279CBE2F0016693E /* tr */,
 				98EAE82C27A5D7D900C6D571 /* en-GB */,
+				5B08850228296B61003D4C2D /* zh-Hant */,
 			);
 			name = EditorView.storyboard;
 			sourceTree = "<group>";
@@ -3830,6 +3889,7 @@
 				2A642CD82390ECB200BCA4C4 /* fr */,
 				08C28F9F279CBE2F0016693E /* tr */,
 				98EAE83027A5D7D900C6D571 /* en-GB */,
+				5B08850628296B61003D4C2D /* zh-Hant */,
 			);
 			name = ProgressView.storyboard;
 			sourceTree = "<group>";
@@ -3846,6 +3906,7 @@
 				2A642CE22392196A00BCA4C4 /* fr */,
 				08C28FA0279CBE2F0016693E /* tr */,
 				98EAE83127A5D7D900C6D571 /* en-GB */,
+				5B08850728296B61003D4C2D /* zh-Hant */,
 			);
 			name = CompactProgressView.storyboard;
 			sourceTree = "<group>";
@@ -3862,6 +3923,7 @@
 				0D51D56C2274EAD700A5D747 /* fr */,
 				08C28F97279CBE2F0016693E /* tr */,
 				98EAE82827A5D7D900C6D571 /* en-GB */,
+				5B0884FE28296B60003D4C2D /* zh-Hant */,
 			);
 			name = DocumentWindow.storyboard;
 			sourceTree = "<group>";
@@ -3878,6 +3940,7 @@
 				2A08C889228E72DC002DC184 /* fr */,
 				08C28FAA279CBE300016693E /* tr */,
 				98EAE83B27A5D7DA00C6D571 /* en-GB */,
+				5B08851028296B61003D4C2D /* zh-Hant */,
 			);
 			name = Credits.html;
 			sourceTree = "<group>";
@@ -3891,6 +3954,7 @@
 				57ED31761FFD892900F16CAD /* pt */,
 				08C28FAB279CBE300016693E /* tr */,
 				98EAE83C27A5D7DA00C6D571 /* en-GB */,
+				5B08851128296B61003D4C2D /* zh-Hant */,
 			);
 			name = Acknowledgments.html;
 			sourceTree = "<group>";
@@ -3907,6 +3971,7 @@
 				0D51D5672274EAD300A5D747 /* fr */,
 				08C28F7F279CBE2C0016693E /* tr */,
 				98EAE81027A5D7D600C6D571 /* en-GB */,
+				5B0884E828296B5F003D4C2D /* zh-Hant */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";
@@ -3923,6 +3988,7 @@
 				0D51D5722274EADA00A5D747 /* fr */,
 				08C28F9D279CBE2F0016693E /* tr */,
 				98EAE82E27A5D7D900C6D571 /* en-GB */,
+				5B08850428296B61003D4C2D /* zh-Hant */,
 			);
 			name = SaveDocumentAccessory.storyboard;
 			sourceTree = "<group>";
@@ -3962,6 +4028,7 @@
 				0D51D5892274EAE400A5D747 /* fr */,
 				08C28F90279CBE2E0016693E /* tr */,
 				98EAE82127A5D7D800C6D571 /* en-GB */,
+				5B0884F828296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxInfoEditView.storyboard;
 			sourceTree = "<group>";
@@ -3978,6 +4045,7 @@
 				0D51D5882274EAE300A5D747 /* fr */,
 				08C28F8F279CBE2E0016693E /* tr */,
 				98EAE82027A5D7D800C6D571 /* en-GB */,
+				5B0884F728296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxFileMappingEditView.storyboard;
 			sourceTree = "<group>";
@@ -3994,6 +4062,7 @@
 				0D51D5872274EAE300A5D747 /* fr */,
 				08C28F8E279CBE2E0016693E /* tr */,
 				98EAE81F27A5D7D800C6D571 /* en-GB */,
+				5B0884F628296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxCompletionsEditView.storyboard;
 			sourceTree = "<group>";
@@ -4010,6 +4079,7 @@
 				0D51D5862274EAE300A5D747 /* fr */,
 				08C28F8D279CBE2E0016693E /* tr */,
 				98EAE81E27A5D7D800C6D571 /* en-GB */,
+				5B0884F528296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxOutlineEditView.storyboard;
 			sourceTree = "<group>";
@@ -4026,6 +4096,7 @@
 				0D51D5852274EAE200A5D747 /* fr */,
 				08C28F8C279CBE2E0016693E /* tr */,
 				98EAE81D27A5D7D800C6D571 /* en-GB */,
+				5B0884F428296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxCommentsEditView.storyboard;
 			sourceTree = "<group>";
@@ -4042,6 +4113,7 @@
 				0D51D5842274EAE200A5D747 /* fr */,
 				08C28F8B279CBE2D0016693E /* tr */,
 				98EAE81C27A5D7D800C6D571 /* en-GB */,
+				5B0884F328296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxTermsEditView.storyboard;
 			sourceTree = "<group>";
@@ -4058,6 +4130,7 @@
 				0D51D5832274EAE200A5D747 /* fr */,
 				08C28F8A279CBE2D0016693E /* tr */,
 				98EAE81B27A5D7D800C6D571 /* en-GB */,
+				5B0884F228296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxEditView.storyboard;
 			sourceTree = "<group>";
@@ -4074,6 +4147,7 @@
 				2A156894245C10880055CD85 /* fr */,
 				08C28FA5279CBE300016693E /* tr */,
 				98EAE83627A5D7DA00C6D571 /* en-GB */,
+				5B08850C28296B61003D4C2D /* zh-Hant */,
 			);
 			name = CharacterPopover.storyboard;
 			sourceTree = "<group>";
@@ -4098,6 +4172,7 @@
 				0D51D57A2274EADE00A5D747 /* fr */,
 				08C28F82279CBE2D0016693E /* tr */,
 				98EAE81327A5D7D700C6D571 /* en-GB */,
+				5B0884EA28296B5F003D4C2D /* zh-Hant */,
 			);
 			name = GeneralPane.storyboard;
 			sourceTree = "<group>";
@@ -4114,6 +4189,7 @@
 				0D51D5712274EAD900A5D747 /* fr */,
 				08C28F9C279CBE2F0016693E /* tr */,
 				98EAE82D27A5D7D900C6D571 /* en-GB */,
+				5B08850328296B61003D4C2D /* zh-Hant */,
 			);
 			name = OpenDocumentAccessory.storyboard;
 			sourceTree = "<group>";
@@ -4130,6 +4206,7 @@
 				0D51D58B2274EAE500A5D747 /* fr */,
 				08C28F93279CBE2E0016693E /* tr */,
 				98EAE82427A5D7D800C6D571 /* en-GB */,
+				5B0884FA28296B60003D4C2D /* zh-Hant */,
 			);
 			name = SyntaxMappingConflictsView.storyboard;
 			sourceTree = "<group>";
@@ -4146,6 +4223,7 @@
 				0D51D58A2274EAE400A5D747 /* fr */,
 				08C28F92279CBE2E0016693E /* tr */,
 				98EAE82327A5D7D800C6D571 /* en-GB */,
+				5B0884F928296B60003D4C2D /* zh-Hant */,
 			);
 			name = EncodingListView.storyboard;
 			sourceTree = "<group>";
@@ -4162,6 +4240,7 @@
 				0D51D56A2274EAD500A5D747 /* fr */,
 				08C28F95279CBE2E0016693E /* tr */,
 				98EAE82627A5D7D900C6D571 /* en-GB */,
+				5B0884FC28296B60003D4C2D /* zh-Hant */,
 			);
 			name = FindPreferencesView.storyboard;
 			sourceTree = "<group>";
@@ -4178,6 +4257,7 @@
 				0D51D5732274EADB00A5D747 /* fr */,
 				08C28F9E279CBE2F0016693E /* tr */,
 				98EAE82F27A5D7D900C6D571 /* en-GB */,
+				5B08850528296B61003D4C2D /* zh-Hant */,
 			);
 			name = PrintPanelAccessory.storyboard;
 			sourceTree = "<group>";
@@ -4194,6 +4274,7 @@
 				0D51D58E2274EAE700A5D747 /* fr */,
 				08C28FA9279CBE300016693E /* tr */,
 				98EAE83A27A5D7DA00C6D571 /* en-GB */,
+				5B08850F28296B61003D4C2D /* zh-Hant */,
 			);
 			name = ColorCodePanelAccessory.storyboard;
 			sourceTree = "<group>";
@@ -4210,6 +4291,7 @@
 				0D51D58D2274EAE700A5D747 /* fr */,
 				08C28FA6279CBE300016693E /* tr */,
 				98EAE83727A5D7DA00C6D571 /* en-GB */,
+				5B08850D28296B61003D4C2D /* zh-Hant */,
 			);
 			name = UnicodeInputView.storyboard;
 			sourceTree = "<group>";
@@ -4226,6 +4308,7 @@
 				0D51D5752274EADC00A5D747 /* fr */,
 				08C28FA1279CBE2F0016693E /* tr */,
 				98EAE83227A5D7DA00C6D571 /* en-GB */,
+				5B08850828296B61003D4C2D /* zh-Hant */,
 			);
 			name = GoToLineView.storyboard;
 			sourceTree = "<group>";
@@ -4250,6 +4333,7 @@
 				0D51D58C2274EAE600A5D747 /* fr */,
 				08C28FA8279CBE300016693E /* tr */,
 				98EAE83927A5D7DA00C6D571 /* en-GB */,
+				5B08850E28296B61003D4C2D /* zh-Hant */,
 			);
 			name = ConsolePanel.storyboard;
 			sourceTree = "<group>";
@@ -4266,6 +4350,7 @@
 				0D51D57F2274EAE100A5D747 /* fr */,
 				08C28F87279CBE2D0016693E /* tr */,
 				98EAE81827A5D7D700C6D571 /* en-GB */,
+				5B0884EF28296B60003D4C2D /* zh-Hant */,
 			);
 			name = FileDropPane.storyboard;
 			sourceTree = "<group>";
@@ -4282,6 +4367,7 @@
 				0D51D5772274EADC00A5D747 /* fr */,
 				08C28FA3279CBE2F0016693E /* tr */,
 				98EAE83427A5D7DA00C6D571 /* en-GB */,
+				5B08850A28296B61003D4C2D /* zh-Hant */,
 			);
 			name = CustomSurroundStringView.storyboard;
 			sourceTree = "<group>";
@@ -4314,6 +4400,7 @@
 				0D51D56E2274EAD800A5D747 /* fr */,
 				08C28F99279CBE2F0016693E /* tr */,
 				98EAE82A27A5D7D900C6D571 /* en-GB */,
+				5B08850028296B61003D4C2D /* zh-Hant */,
 			);
 			name = OutlineView.storyboard;
 			sourceTree = "<group>";

--- a/CotEditor/zh-Hant.lproj/Acknowledgments.html
+++ b/CotEditor/zh-Hant.lproj/Acknowledgments.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="zh-Hant-TW">
+<head>
+    <meta charset="UTF-8"/>
+    <title>致謝</title>
+    <link rel="stylesheet" href="../Base.lproj/Acknowledgments.css"/>
+</head>
+
+<body>
+<h1>致謝</h1>
+
+<p>CotEditor在開發中使用了下面這些出色的技術。我們對於那些允許我們使用他們寶貴的程式/資訊來開發CotEditor的人致以最誠摯的感謝。</p>
+
+
+<section id="Libraries">
+<section class="Sparkle">
+<h3>Sparkle <span>(only on non-AppStore ver.)</span></h3>
+<p><a href="https://sparkle-project.org">https://sparkle-project.org</a></p>
+<p>感謝Andy Matuschak等人的軟體升級框架Sparkle。Sparkle是遵循如下<em>MIT許可證</em>釋出的。</p>
+
+<details>
+<summary>MIT license</summary>
+<blockquote><pre>
+© 2006-2013 Andy Matuschak
+© 2009-2013 Elgato Systems GmbH.
+© 2011-2014 Kornel Lesiński
+© 2015-2017 Mayur Pawashe
+© 2014 C.W. Betts
+© 2014 Petroules Corporation
+© 2014 Big Nerd Ranch
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+=================
+EXTERNAL LICENSES
+=================
+
+bspatch.c and bsdiff.c, from bsdiff 4.3 &lt;http://www.daemonology.net/bsdiff/&gt;:
+    Copyright (c) 2003-2005 Colin Percival.
+
+sais.c and sais.c, from sais-lite (2010/08/07) &lt;https://sites.google.com/site/yuta256/sais&gt;:
+    Copyright (c) 2008-2010 Yuta Mori.
+
+SUSignatureVerifier.m:
+    Copyright (c) 2011 Mark Hamlin.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted providing that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></blockquote>
+</details>
+</section>
+
+
+<section>
+<h3>Yams</h3>
+<p><a href="https://github.com/jpsim/Yams">https://github.com/jpsim/Yams</a></p>
+<p>感謝JP Simard的Yams，這是一個LibYAML的Swift版本轉換。Yams是遵循如下<em>MIT許可證</em>釋出的。</p>
+
+<details>
+<summary>MIT license</summary>
+<blockquote><pre>
+Copyright (c) 2016 JP Simard.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre></blockquote>
+</details>
+</section>
+
+
+<section>
+<h3>Solarized</h3>
+<p><a href="https://ethanschoonover.com/solarized">https://ethanschoonover.com/solarized</a></p>
+<p>感謝Ethan Schoonover的Solarized顏色主題。CotEditor的預設主題“Solarized (Light)”和“Solarized (Dark)”是基於這個顏色主題的。Solarized是遵循如下<em>MIT許可證</em>釋出的。</p>
+
+<details>
+<summary>MIT license</summary>
+<blockquote><pre>
+Copyright (c) 2011 Ethan Schoonover
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre></blockquote>
+</details>
+</section>
+
+
+<section>
+<h3>WFColorCode</h3>
+<p><a href="https://github.com/1024jp/WFColorCode">https://github.com/1024jp/WFColorCode</a></p>
+<p>WFColorCode是由1024jp開發的，並遵循如下<em>MIT許可證</em>釋出。</p>
+
+<details>
+<summary>MIT license</summary>
+<blockquote><pre>
+© 2014-2022 1024jp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre></blockquote>
+</details>
+</section>
+</section>
+
+
+<section id="InfoSource">
+<h2>其他資訊</h2>
+<ul>
+    <li>感謝FUJIDANA &lt;<a>http://blogs.dion.ne.jp/fujidana/archives/4169016.html</a>&gt;的FJDDetectEncoding，CotEditor的’編碼自動檢測 (ISO 2022-JP, UTF-8, UTF-16)是基於其開發的。FJDDetectEncoding遵守<em>BSD許可證</em>。</li>
+    <li>感謝Daisuke Kamiyama &lt;<a href="https://www.mimikaki.net/">https://www.mimikaki.net</a>&gt;的mi，提供了CotEditor's檔案拖拽功能用到的預格式化字串。</li>
+</ul>
+</section>
+
+
+<section id="Contributors">
+<h2>貢獻者</h2>
+<p>CotEditor 包含了以下人員提供的資料和資訊。我們在此對幫助過我們的人致以感謝。</p>
+
+<ul>
+    <li>本地化：<ul>
+        <li>簡體中文<br/>
+            Wei Wang (onevcat) &lt;<a href="https://onevcat.com">https://onevcat.com</a>&gt;</li>
+        <li>繁體中文<br/>
+            Wei Wang (onevcat) &lt;<a href="https://onevcat.com">https://onevcat.com</a>&gt;</li>
+            Shiki Suen (shikisuen) @ Atelier Inmu &lt;<a href="https://shiki.inmu.pro/about/">https://shiki.inmu.pro/about/</a>&gt;</li>
+        <li>法語<br/>
+            Aurélien Roy &lt;<a href="https://github.com/aurelien-roy">https://github.com/aurelien-roy</a>&gt;</li>
+        <li>義大利文<br/>
+            Agostino Maiello</li>
+        <li>葡萄牙語 (巴西)<br/>
+            BR Lingo &lt;<a href="https://brlingo.com">https://brlingo.com</a>&gt;</li>
+        <li>土耳其語<br/>
+            Emir SARI</li>
+    </ul></li>
+    
+    <li>文法風格檔案:<ul>
+        <li>METAFONT<br/>
+            M.Daimon &lt;<a href="https://github.com/VoD">https://github.com/VoD</a>&gt;</li>
+        <li>Pascal<br/>
+            cbnbg</li>
+    </ul></li>
+    
+    <li>指令碼鉤子實現:<ul>
+        <li>Kaito Udagawa &lt;<a href="https://github.com/umireon">https://github.com/umireon</a>&gt;</li>
+    </ul></li>
+    
+    <li>自動縮排改進:<ul>
+        <li>Naotaka Morimoto &lt;<a href="http://naotaka.com/">http://naotaka.com</a>&gt;</li>
+    </ul></li>
+    
+    <li>字元顯示器改進，NFKC Casefold, 修改NFC, 修改NFD標準化支援:<ul>
+        <li>Yusuke Terada &lt;<a href="https://doratex.hatenablog.jp/">https://doratex.hatenablog.jp</a>&gt;</li>
+    </ul></li>
+</ul>
+
+<section>
+<h3>Contributors on the original CotEditor (≦ 1.0)</h3>
+<ul>
+    <li>本地化：<ul>
+        <li>英文 (文稿和幫助檔案)<br/>
+            Y. Yamamoto</li>
+    </ul></li>
+    
+    <li>文法風格檔案:<ul>
+        <li>PHP<br/>
+            kaz &lt;<a href="https://github.com/kaz6120">https://github.com/kaz6120</a>&gt;</li>
+        <li>LaTeX<br/>
+            Yuhei Kuratomi &lt;<a>http://www.tomapd.net</a>&gt;</li>
+        <li>Ruby<br/>
+            Y. Tokutomi &lt;<a href="https://heartbeat.tommy1969.com">https://heartbeat.tommy1969.com</a>&gt;</li>
+        <li>Haskell<br/>
+            konn &lt;<a href="https://konn-san.com">https://konn-san.com</a>&gt;</li>
+        <li>Python<br/>
+            nanasiya &lt;<a>http://mahonet.info/~nanasiya/</a>&gt;</li>
+    </ul></li>
+    
+    <li>本地化技術支援，原始的日語本地化和幫助檔案 (ja):<ul>
+        <li>Hiroto Sakai &lt;<a href="http://www.fan.gr.jp/~sakai/">http://www.fan.gr.jp/~sakai/</a>&gt;</li>
+    </ul></li>
+    
+    <li>更好的行號顯示，文字顏色和自動補全:<ul>
+        <li>Hetima &lt;<a href="http://hetima.com/">http://hetima.com</a>&gt;</li>
+    </ul></li>
+    
+    <li>更好的“補全彈出”:<ul>
+        <li>Haruka Kataoka &lt;<a href="https://drumsoft.com/">https://drumsoft.com</a>&gt;</li>
+    </ul></li>
+</ul>
+</section>
+</section>
+
+
+<section id="Project">
+<h2>CotEditor專案</h2>
+<p>CotEditor最早由nakamuxu &lt;<a href="https://www.aynimac.com">https://www.aynimac.com</a>&gt;開發, 現在由1024jp &lt;<a href="http://wolfrosch.com">http://wolfrosch.com</a>&gt;開發。</p>
+</section>
+</body>
+</html>

--- a/CotEditor/zh-Hant.lproj/AppearancePane.strings
+++ b/CotEditor/zh-Hant.lproj/AppearancePane.strings
@@ -1,0 +1,183 @@
+//
+//  AppearancePane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Font:"; ObjectID = "Z85-S9-uID"; */
+"Z85-S9-uID.title" = "字型：";
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "3289"; */
+"3289.title" = "選擇…";
+/* Class = "NSButtonCell"; title = "Anti-aliasing"; ObjectID = "3290"; */
+"3290.title" = "抗鋸齒";
+/* Class = "NSButtonCell"; title = "Ligatures"; ObjectID = "g3S-3v-6ZA"; */
+"g3S-3v-6ZA.title" = "連字";
+
+/* Class = "NSTextFieldCell"; title = "Line height:"; ObjectID = "r1c-v3-qW1"; */
+"r1c-v3-qW1.title" = "行高：";
+/* Class = "NSTextFieldCell"; title = "times"; ObjectID = "VLD-jj-zzl"; */
+"VLD-jj-zzl.title" = "倍";
+
+/* Class = "NSTextFieldCell"; title = "Current line:"; ObjectID = "oKu-Fu-hRU"; */
+"oKu-Fu-hRU.title" = "當前行：";
+/* Class = "NSButtonCell"; title = "Change background color"; ObjectID = "ba7-dE-zXz"; */
+"ba7-dE-zXz.title" = "改變背景顏色";
+
+/* Class = "NSTextFieldCell"; title = "Cursor:"; ObjectID = "NIq-Tj-KWB"; */
+"NIq-Tj-KWB.title" = "游標：";
+/* Class = "NSButtonCell"; title = "Bar"; ObjectID = "cnD-9F-CR4"; */
+"cnD-9F-CR4.title" = "條";
+/* Class = "NSButtonCell"; title = "Thick bar"; ObjectID = "rM6-JW-wau"; */
+"rM6-JW-wau.title" = "粗條";
+/* Class = "NSButtonCell"; title = "Block"; ObjectID = "YG7-Y7-xzs"; */
+"YG7-Y7-xzs.title" = "塊";
+
+
+/* Class = "NSTextFieldCell"; title = "Invisibles:"; ObjectID = "oAZ-6U-Ba8"; */
+"oAZ-6U-Ba8.title" = "不可見元素：";
+/* Class = "NSButtonCell"; title = "Show invisible characters"; ObjectID = "gqy-Io-eUU"; */
+"gqy-Io-eUU.title" = "顯示不可見元素";
+/* Class = "NSButtonCell"; title = "Line ending"; ObjectID = "Ont-7L-Uf5"; */
+"Ont-7L-Uf5.title" = "行尾";
+/* Class = "NSButtonCell"; title = "Tab"; ObjectID = "XSb-uU-5QP"; */
+"XSb-uU-5QP.title" = "Tab";
+/* Class = "NSButtonCell"; title = "Space"; ObjectID = "gcF-OM-SV0"; */
+"gcF-OM-SV0.title" = "空格";
+/* Class = "NSButtonCell"; title = "Other whitespaces"; ObjectID = "Bf2-rS-2zu"; */
+"Bf2-rS-2zu.title" = "其他空白字元";
+/* Class = "NSButtonCell"; title = "Other control characters"; ObjectID = "sxg-F3-ely"; */
+"sxg-F3-ely.title" = "其他控制字元";
+/* Class = "NSButtonCell"; title = "Show indent guides"; ObjectID = "csp-Hi-hb1"; */
+"csp-Hi-hb1.title" = "顯示縮排指示";
+
+/* Class = "NSTextFieldCell"; title = "Appearance:"; ObjectID = "6KG-3a-ZuU"; */
+"6KG-3a-ZuU.title" = "外觀：";
+/* Class = "NSButtonCell"; title = "Match System"; ObjectID = "apQ-au-gOC"; */
+"apQ-au-gOC.title" = "匹配系統";
+/* Class = "NSButtonCell"; title = "Light"; ObjectID = "FwU-oj-kwc"; */
+"FwU-oj-kwc.title" = "淺色";
+/* Class = "NSButtonCell"; title = "Dark"; ObjectID = "1Cg-21-kjr"; */
+"1Cg-21-kjr.title" = "深色";
+
+
+/* Class = "NSTableColumn"; headerCell.title = "Theme"; ObjectID = "Avf-y8-wXG"; */
+"Avf-y8-wXG.headerCell.title" = "主題";
+/* Class = "NSMenuItem"; title = "Import…"; ObjectID = "gcs-B8-kPL"; */
+"gcs-B8-kPL.title" = "匯入…";
+/* Class = "NSMenuItem"; title = "Export…"; ObjectID = "4B4-mq-8Fs"; */
+"4B4-mq-8Fs.title" = "匯出…";
+/* Class = "NSButtonCell"; title = "Reload All Themes"; ObjectID = "7Yp-bg-3l6"; */
+"7Yp-bg-3l6.title" = "過載所有主題";
+
+
+/* contextual menu */
+/* Class = "NSMenuItem"; title = "New Theme"; ObjectID = "sJb-7g-2FN"; */
+"sJb-7g-2FN.title" = "新增主題";
+/* Class = "NSMenuItem"; title = "Rename"; ObjectID = "nWy-OL-CGi"; */
+"nWy-OL-CGi.title" = "重新命名";
+/* Class = "NSMenuItem"; title = "Duplicate"; ObjectID = "9LW-xw-HBP"; */
+"9LW-xw-HBP.title" = "複製";
+/* Class = "NSMenuItem"; title = "Restore"; ObjectID = "vTP-Fc-iBF"; */
+"vTP-Fc-iBF.title" = "還原";
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "WNG-Ai-RdG"; */
+"WNG-Ai-RdG.title" = "刪除";
+/* Class = "NSMenuItem"; title = "Export…"; ObjectID = "ueG-D7-DSV"; */
+"ueG-D7-DSV.title" = "匯入…";
+/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "UMs-gY-YHE"; */
+"UMs-gY-YHE.title" = "在訪達中顯示";
+/* Class = "NSMenuItem"; title = "Import…"; ObjectID = "52n-xG-4ZL"; */
+"52n-xG-4ZL.title" = "匯出…";
+
+
+
+/* Theme View */
+
+/* Class = "NSTextFieldCell"; title = "Characters:"; ObjectID = "kvy-vf-yva"; */
+"kvy-vf-yva.title" = "文字：";
+/* Class = "NSTextFieldCell"; title = "Cursor:"; ObjectID = "Ljk-ky-fQH"; */
+"Ljk-ky-fQH.title" = "游標：";
+/* Class = "NSTextFieldCell"; title = "Invisibles:"; ObjectID = "IGx-p1-FHi"; */
+"IGx-p1-FHi.title" = "不可見元素：";
+/* Class = "NSTextFieldCell"; title = "Background:"; ObjectID = "tvj-DS-DVt"; */
+"tvj-DS-DVt.title" = "背景：";
+/* Class = "NSTextFieldCell"; title = "Current Line:"; ObjectID = "yMW-lO-ILw"; */
+"yMW-lO-ILw.title" = "當前行：";
+/* Class = "NSTextFieldCell"; title = "Selection:"; ObjectID = "PbY-c2-p4V"; */
+"PbY-c2-p4V.title" = "選中：";
+/* Class = "NSButtonCell"; title = "Use system color"; ObjectID = "0ZP-Zp-oBu"; */
+"0ZP-Zp-oBu.title" = "使用系統顏色";
+
+
+/* Class = "NSTextFieldCell"; title = "Syntax"; ObjectID = "F64-8o-JYC"; */
+"F64-8o-JYC.title" = "文法";
+
+/* Class = "NSTextFieldCell"; title = "Keywords:"; ObjectID = "IU8-bd-gBv"; */
+"IU8-bd-gBv.title" = "關鍵字：";
+/* Class = "NSTextFieldCell"; title = "Commands:"; ObjectID = "81x-je-JUf"; */
+"81x-je-JUf.title" = "命令：";
+/* Class = "NSTextFieldCell"; title = "Types:"; ObjectID = "ILi-Jt-MUc"; */
+"ILi-Jt-MUc.title" = "型別：";
+/* Class = "NSTextFieldCell"; title = "Attributes:"; ObjectID = "RQL-fz-3aq"; */
+"RQL-fz-3aq.title" = "標記：";
+/* Class = "NSTextFieldCell"; title = "Variables:"; ObjectID = "ZIr-1E-qZJ"; */
+"ZIr-1E-qZJ.title" = "變數：";
+/* Class = "NSTextFieldCell"; title = "Values:"; ObjectID = "cVK-ET-QiD"; */
+"cVK-ET-QiD.title" = "值：";
+/* Class = "NSTextFieldCell"; title = "Numbers:"; ObjectID = "3wF-uc-Tfq"; */
+"3wF-uc-Tfq.title" = "數字：";
+/* Class = "NSTextFieldCell"; title = "Strings:"; ObjectID = "n04-r3-95l"; */
+"n04-r3-95l.title" = "字串：";
+/* Class = "NSTextFieldCell"; title = "Text:"; ObjectID = "hbk-iX-4VK"; */
+"hbk-iX-4VK.title" = "字元：";
+/* Class = "NSTextFieldCell"; title = "Characters:"; ObjectID = "kvy-vf-yva"; */
+"kvy-vf-yva.title" = "文字：";
+/* Class = "NSTextFieldCell"; title = "Comments:"; ObjectID = "AIG-rr-79V"; */
+"AIG-rr-79V.title" = "註釋：";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Show theme file information"; ObjectID = "8zj-4c-Hg4"; */
+"8zj-4c-Hg4.ibShadowedToolTip" = "顯示主題檔案資訊";
+
+
+
+/* Metadata View */
+
+/* Class = "NSTextFieldCell"; title = "Author:""; ObjectID = "jbY-IC-CRS"; */
+"jbY-IC-CRS.title" = "作者：";
+/* Class = "NSTextFieldCell"; title = "URL:"; ObjectID = "xyY-jQ-kpJ"; */
+"xyY-jQ-kpJ.title" = "URL：";
+/* Class = "NSTextFieldCell"; title = "License:"; ObjectID = "iy5-9x-zGF"; */
+"iy5-9x-zGF.title" = "許可證：";
+/* Class = "NSTextFieldCell"; title = "Description:"; ObjectID = "Inh-Ci-NGp"; */
+"Inh-Ci-NGp.title" = "描述：";
+
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not defined"; ObjectID = "8ur-1G-I4N"; */
+"8ur-1G-I4N.ibShadowedIsNilPlaceholder" = "未定義";
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not defined"; ObjectID = "wN3-ao-X42"; */
+"wN3-ao-X42.ibShadowedIsNilPlaceholder" = "未定義";
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not defined"; ObjectID = "AVc-Ci-UnL"; */
+"AVc-Ci-UnL.ibShadowedIsNilPlaceholder" = "未定義";
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not defined"; ObjectID = "rpX-lj-tHS"; */
+"rpX-lj-tHS.ibShadowedIsNilPlaceholder" = "未定義";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Jump to URL"; ObjectID = "Usu-Br-G0a"; */
+"Usu-Br-G0a.ibShadowedToolTip" = "跳轉到URL";

--- a/CotEditor/zh-Hant.lproj/CharacterPopover.strings
+++ b/CotEditor/zh-Hant.lproj/CharacterPopover.strings
@@ -1,0 +1,30 @@
+//
+//  CharacterPopover.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2020-05-01.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2020-2022 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "No Block"; ObjectID = "gXn-Gb-4VD"; */
+"gXn-Gb-4VD.ibShadowedIsNilPlaceholder" = "無Block";
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "No Category"; ObjectID = "zT1-ln-MpC"; */
+"zT1-ln-MpC.ibShadowedIsNilPlaceholder" = "未分類";

--- a/CotEditor/zh-Hant.lproj/ColorCodePanelAccessory.strings
+++ b/CotEditor/zh-Hant.lproj/ColorCodePanelAccessory.strings
@@ -1,0 +1,48 @@
+//
+//  ColorCodePanelAccessory.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "color code"; ObjectID = "JAw-oC-vv2"; */
+"JAw-oC-vv2.ibShadowedIsNilPlaceholder" = "顏色碼";
+/* Class = "CocoaBindingsConnection"; ibShadowedNoSelectionPlaceholder = "no selection"; ObjectID = "JAw-oC-vv2"; */
+"JAw-oC-vv2.ibShadowedNoSelectionPlaceholder" = "沒有選中";
+
+/* Class = "NSButtonCell"; title = "Insert"; ObjectID = "HMC-PY-Ngy"; */
+"HMC-PY-Ngy.title" = "插入";
+
+/* Class = "NSMenuItem"; title = "Hexadecimal"; ObjectID = "vF1-in-Dlv"; */
+"vF1-in-Dlv.title" = "Hex";
+/* Class = "NSMenuItem"; title = "Hexadecimal (Short)"; ObjectID = "wEc-KD-y7s"; */
+"wEc-KD-y7s.title" = "Hex（短）";
+/* Class = "NSMenuItem"; title = "CSS RGB"; ObjectID = "6bH-jm-mNR"; */
+"6bH-jm-mNR.title" = "CSS RGB";
+/* Class = "NSMenuItem"; title = "CSS RGBa"; ObjectID = "cxo-sm-Sx5"; */
+"cxo-sm-Sx5.title" = "CSS RGBa";
+/* Class = "NSMenuItem"; title = "CSS HSL"; ObjectID = "TnX-U4-Fkz"; */
+"TnX-U4-Fkz.title" = "CSS HSL";
+/* Class = "NSMenuItem"; title = "CSS HSLa"; ObjectID = "k4U-AQ-5ws"; */
+"k4U-AQ-5ws.title" = "CSS HSLa";
+/* Class = "NSMenuItem"; title = "CSS Keyword"; ObjectID = "dY5-ZH-n6l"; */
+"dY5-ZH-n6l.title" = "CSS關鍵字";

--- a/CotEditor/zh-Hant.lproj/CompactProgressView.strings
+++ b/CotEditor/zh-Hant.lproj/CompactProgressView.strings
@@ -1,0 +1,28 @@
+//
+//  CompactProgressView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2019-11-30.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2019-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSButton"; ibShadowedToolTip = "Cancel operation."; ObjectID = "Jua-5O-j1x"; */
+"Jua-5O-j1x.ibShadowedToolTip" = "取消操作";

--- a/CotEditor/zh-Hant.lproj/ConsolePanel.strings
+++ b/CotEditor/zh-Hant.lproj/ConsolePanel.strings
@@ -1,0 +1,33 @@
+//
+//  ConsolePanel.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2015 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSPanel"; title = "Console"; ObjectID = "6"; */
+"6.title" = "主控台";
+
+/* Class = "NSToolbarItem"; ObjectID = "Yei-b2-m1J"; */
+"Yei-b2-m1J.label" = "清空記錄";  /* Clear Log */
+"Yei-b2-m1J.paletteLabel" = "清空記錄";  /* Clear Log */
+"Yei-b2-m1J.toolTip" = "清空錯誤記錄";  /* Clear error log */

--- a/CotEditor/zh-Hant.lproj/Credits.html
+++ b/CotEditor/zh-Hant.lproj/Credits.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="zh-Hant-TW">
+    <head>
+        <meta charset="UTF-8"/>
+        <title>Credits</title>
+        <link rel="stylesheet" href="../Base.lproj/Credits.css"/>
+    </head>
+    
+    <body>
+        <h2>CotEditor 專案</h2>
+        <p>1024jp</p>
+        <p></p>
+        
+        <h2>本地化</h2>
+        <p>簡體中文 – Wei Wang</p>
+        <p>繁體中文 – Wei Wang & Shiki Suen</p>
+        <p>法語 – Aurélien Roy</p>
+        <p>義大利語 – Agostino Maiello</p>
+        <p>葡萄牙語 – BR Lingo</p>
+        <p>土耳其語 - Emir SARI</p>
+        <p></p>
+        
+        <h2>第三方程式碼</h2>
+        <p>JP Simard 的 Yams</p>
+        <p class="Sparkle">Andy Matuschak 等人的 Sparkle</p>
+        <p></p>
+        
+        <h2>特別感謝</h2>
+        <p>nakamuxu (原開發者)</p>
+        <p>… 以及所有其他貢獻者</p>
+        <p></p>
+        
+        <p class="hr">: : : : : :</p>
+        
+        <p>CotEditor 是基於<br/>
+           Apache 協議 2.0 版的開源軟體</p>
+        <p><a href="https://github.com/coteditor">https://github.com/coteditor</a></p>
+    </body>
+</html>

--- a/CotEditor/zh-Hant.lproj/CustomSurroundStringView.strings
+++ b/CotEditor/zh-Hant.lproj/CustomSurroundStringView.strings
@@ -1,0 +1,38 @@
+//
+//  CustomSurroundStringView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2017-03-19.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2017 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Surround With:"; ObjectID = "rgF-DI-5tb"; */
+"rgF-DI-5tb.title" = "進行環繞：";
+
+/* Class = "NSTextFieldCell"; title = "Begin:"; ObjectID = "Gyd-g5-olo"; */
+"Gyd-g5-olo.title" = "開頭：";
+/* Class = "NSTextFieldCell"; title = "End:"; ObjectID = "I9c-rv-hHo"; */
+"I9c-rv-hHo.title" = "結尾：";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "xm5-Ft-kfG"; */
+"xm5-Ft-kfG.title" = "取消";
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "9Pu-Ep-7fQ"; */
+"9Pu-Ep-7fQ.title" = "好";

--- a/CotEditor/zh-Hant.lproj/CustomTabWidthView.strings
+++ b/CotEditor/zh-Hant.lproj/CustomTabWidthView.strings
@@ -1,0 +1,33 @@
+//
+//  CustomTabWidthView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2018-07-07.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2018-2022 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Tab width:"; ObjectID = "ql5-25-UDJ"; */
+"ql5-25-UDJ.title" = "Tab寬度：";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "bJM-c0-iOi"; */
+"bJM-c0-iOi.title" = "取消";
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "Vkm-Ud-cTc"; */
+"Vkm-Ud-cTc.title" = "好";

--- a/CotEditor/zh-Hant.lproj/DocumentInspectorView.strings
+++ b/CotEditor/zh-Hant.lproj/DocumentInspectorView.strings
@@ -1,0 +1,84 @@
+//
+//  DocumentInfoView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-18.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Document File"; ObjectID = "5tP-OA-Ujw"; */
+"5tP-OA-Ujw.title" = "文件檔案";
+
+/* Class = "NSTextFieldCell"; title = "Created"; ObjectID = "hgp-Cc-KHJ"; */
+"hgp-Cc-KHJ.title" = "建立於";
+/* Class = "NSTextFieldCell"; title = "Modified"; ObjectID = "BtZ-Pl-H7s"; */
+"BtZ-Pl-H7s.title" = "最後編輯";
+/* Class = "NSTextFieldCell"; title = "Size"; ObjectID = "uZa-Q9-nHs"; */
+"uZa-Q9-nHs.title" = "大小";
+/* Class = "NSTextFieldCell"; title = "Owner"; ObjectID = "AjV-U0-lC7"; */
+"AjV-U0-lC7.title" = "擁有者";
+/* Class = "NSTextFieldCell"; title = "Permissions"; ObjectID = "N0Y-nO-k3L"; */
+"N0Y-nO-k3L.title" = "許可權";
+/* Class = "NSTextFieldCell"; title = "Full Path"; ObjectID = "zwU-xo-iZu"; */
+"zwU-xo-iZu.title" = "完整路徑";
+
+
+/* Class = "NSTextFieldCell"; title = "Text Settings"; ObjectID = "8KW-Mc-cRX"; */
+"8KW-Mc-cRX.title" = "文字設定";
+
+/* Class = "NSTextFieldCell"; title = "Encoding"; ObjectID = "B5F-j1-X4E"; */
+"B5F-j1-X4E.title" = "編碼";
+/* Class = "NSTextFieldCell"; title = "Line Endings"; ObjectID = "XBS-xa-s3p"; */
+"XBS-xa-s3p.title" = "行尾";
+
+
+/* Class = "NSTextFieldCell"; title = "Count"; ObjectID = "cbf-0f-9rd"; */
+"cbf-0f-9rd.title" = "計數";
+
+/* Class = "NSTextFieldCell"; title = "Lines"; ObjectID = "yRM-Y0-4Oq"; */
+"yRM-Y0-4Oq.title" = "行數";
+/* Class = "NSTextFieldCell"; title = "Characters"; ObjectID = "e1m-Uo-4UK"; */
+"e1m-Uo-4UK.title" = "字元數";
+/* Class = "NSTextFieldCell"; title = "Length"; ObjectID = "H0d-Eg-DcW"; */
+"H0d-Eg-DcW.title" = "長度";
+/* Class = "NSTextFieldCell"; title = "Words"; ObjectID = "tZ6-05-eKf"; */
+"tZ6-05-eKf.title" = "字數";
+
+/* Class = "NSTextFieldCell"; title = "Location"; ObjectID = "nXT-Oq-0l6"; */
+"nXT-Oq-0l6.title" = "位置";
+
+/* Class = "NSTextFieldCell"; title = "Location"; ObjectID = "ERr-yA-dIa"; */
+"ERr-yA-dIa.title" = "位置";
+/* Class = "NSTextFieldCell"; title = "Current Line"; ObjectID = "f9g-dQ-g3K"; */
+"f9g-dQ-g3K.title" = "當前行";
+/* Class = "NSTextFieldCell"; title = "Column"; ObjectID = "Wwr-gI-HPc"; */
+"Wwr-gI-HPc.title" = "列";
+
+
+/* Class = "NSTextFieldCell"; title = "Character"; ObjectID = "H2Z-jU-biZ"; */
+"H2Z-jU-biZ.title" = "字元";
+
+/* Class = "NSTextFieldCell"; title = "Code Points"; ObjectID = "kna-yU-liB"; */
+"kna-yU-liB.title" = "碼點";
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not selected"; ObjectID = "sru-km-SZJ"; */
+"sru-km-SZJ.ibShadowedIsNilPlaceholder" = "未選中";
+/* Class = "NSTextField"; ibShadowedToolTip = "Select a single character to show Unicode information."; ObjectID = "2ZU-Mi-aJz"; */
+"2ZU-Mi-aJz.ibShadowedToolTip" = "選中一個字元以顯示Unicode資訊。";

--- a/CotEditor/zh-Hant.lproj/DocumentWindow.strings
+++ b/CotEditor/zh-Hant.lproj/DocumentWindow.strings
@@ -1,0 +1,79 @@
+//
+//  DocumentWindow.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTabViewItem"; label = "Document Inspector"; ObjectID = "Kfj-q6-61N"; */
+"Kfj-q6-61N.label" = "文稿資訊";
+/* Class = "NSTabViewItem"; label = "Outline"; ObjectID = "hyM-2j-hen"; */
+"hyM-2j-hen.label" = "大綱";
+/* Class = "NSTabViewItem"; label = "Warnings"; ObjectID = "JZo-ok-Dks"; */
+"JZo-ok-Dks.label" = "警告";
+
+
+/* Class = "NSTextFieldCell"; title = "Editor’s Opacity"; ObjectID = "Are-7I-6OR"; */
+"Are-7I-6OR.title" = "編輯器透明度";
+/* Class = "NSView"; ibShadowedToolTip = "Transparent"; ObjectID = "EVo-Ee-gQ1"; */
+"EVo-Ee-gQ1.ibShadowedToolTip" = "透明";
+/* Class = "NSView"; ibShadowedToolTip = "Opaque"; ObjectID = "8NN-KX-RmA"; */
+"8NN-KX-RmA.ibShadowedToolTip" = "不透明";
+
+
+/* Class = "NSPopUpButton"; title = "File encoding"; ObjectID = "CUv-So-9Og"; */
+"CUv-So-9Og.ibShadowedToolTip" = "檔案編碼";
+/* Class = "NSMenuItem"; title = "File Encoding"; ObjectID = "mS8-3F-93y"; */
+"q4F-Uw-VL4.title" = "檔案編碼";
+
+/* Class = "NSMenuItem"; title = "Line Endings"; ObjectID = "mS8-3F-93y"; */
+"mS8-3F-93y.title" = "行尾";
+/* Class = "NSMenuItem"; title = "LF"; ObjectID = "YT7-vd-3ih"; */
+"YT7-vd-3ih.title" = "LF";
+/* Class = "NSMenuItem"; title = "CR"; ObjectID = "J48-tF-WBo"; */
+"J48-tF-WBo.title" = "CR";
+/* Class = "NSMenuItem"; title = "CRLF"; ObjectID = "Zo1-Cc-YBm"; */
+"Zo1-Cc-YBm.title" = "CRLF";
+/* Class = "NSMenuItem"; title = "NEL"; ObjectID = "T5S-w3-Q1V"; */
+"T5S-w3-Q1V.title" = "NEL";
+/* Class = "NSMenuItem"; title = "LS"; ObjectID = "ayd-8d-C4Y"; */
+"ayd-8d-C4Y.title" = "LS";
+/* Class = "NSMenuItem"; title = "PS"; ObjectID = "YIk-KP-44u"; */
+"YIk-KP-44u.title" = "PS";
+
+
+/* Class = "NSTextField"; title = "File Size"; ObjectID = "EJU-9e-uCA"; */
+"EJU-9e-uCA.ibShadowedToolTip" = "檔案尺寸";
+/* Class = "NSPopUpButton"; title = "Line endings"; ObjectID = "FNE-H9-iZR"; */
+"FNE-H9-iZR.ibShadowedToolTip" = "行尾";
+/* Class = "NSMenuItem"; ibShadowedToolTip = "macOS / Unix"; ObjectID = "YT7-vd-3ih"; */
+"YT7-vd-3ih.ibShadowedToolTip" = "macOS / Unix";
+/* Class = "NSMenuItem"; ibShadowedToolTip = "Classic Mac OS"; ObjectID = "J48-tF-WBo"; */
+"J48-tF-WBo.ibShadowedToolTip" = "Classic Mac OS";
+/* Class = "NSMenuItem"; ibShadowedToolTip = "Windows"; ObjectID = "Zo1-Cc-YBm"; */
+"Zo1-Cc-YBm.ibShadowedToolTip" = "Windows";
+/* Class = "NSMenuItem"; ibShadowedToolTip = "Unix Next Line"; ObjectID = "T5S-w3-Q1V"; */
+"T5S-w3-Q1V.ibShadowedToolTip" = "Unix Next Line";  // Unlike other line endings, this item is preferably as-is because of the unfamiliarity.
+/* Class = "NSMenuItem"; ibShadowedToolTip = "Unix Line Separator"; ObjectID = "ayd-8d-C4Y"; */
+"ayd-8d-C4Y.ibShadowedToolTip" = "Unix Line Separator";  // Unlike other line endings, this item is preferably as-is because of the unfamiliarity.
+/* Class = "NSMenuItem"; ibShadowedToolTip = "Unix Paragraph Separator"; ObjectID = "YIk-KP-44u"; */
+"YIk-KP-44u.ibShadowedToolTip" = "Unix Paragraph Separator";  // Unlike other line endings, this item is preferably as-is because of the unfamiliarity.

--- a/CotEditor/zh-Hant.lproj/EditPane.strings
+++ b/CotEditor/zh-Hant.lproj/EditPane.strings
@@ -1,0 +1,97 @@
+//
+//  EditPane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Substitution:"; ObjectID = "SqI-BC-ar9"; */
+"SqI-BC-ar9.title" = "替換：";
+/* Class = "NSButtonCell"; title = "Smart copy/paste"; ObjectID = "3302"; */
+"3302.title" = "智慧複製/貼上";
+/* Class = "NSButtonCell"; title = "Automatically insert closing brackets and quotes"; ObjectID = "GRh-V2-hmW"; */
+"GRh-V2-hmW.title" = "自動補全括弧和引號";
+/* Class = "NSButtonCell"; title = "Swap “¥” and “\\” keys"; ObjectID = "3303"; */
+"3303.title" = "轉換“¥”和“\\”按鍵";
+/* Class = "NSTextFieldCell"; title = "Smart"; ObjectID = "6I3-dM-2QV"; */
+"6I3-dM-2QV.title" = "智慧";
+/* Class = "NSButtonCell"; title = "Quotes"; ObjectID = "Abx-fM-gyc"; */
+"Abx-fM-gyc.title" = "引號";
+/* Class = "NSButtonCell"; title = "Dashes"; ObjectID = "nr1-0X-aBY"; */
+"nr1-0X-aBY.title" = "破折號";
+/* Class = "NSButtonCell"; title = "Automatically trim trailing whitespace"; ObjectID = "noP-hx-YeQ"; */
+"noP-hx-YeQ.title" = "自動去除末尾空格";
+/* Class = "NSButtonCell"; title = "Including whitespace-only lines"; ObjectID = "Tma-Oh-F7v"; */
+"Tma-Oh-F7v.title" = "包含只有空格的行";
+
+
+/* Class = "NSTextFieldCell"; title = "Indentation:"; ObjectID = "9bX-ei-1x8"; */
+"9bX-ei-1x8.title" = "縮排：";
+/* Class = "NSButtonCell"; title = "Automatic indent"; ObjectID = "3285"; */
+"3285.title" = "自動縮排";
+/* Class = "NSButtonCell"; title = "Expand tabs to spaces"; ObjectID = "3283"; */
+"3283.title" = "將tab轉換為空格";
+/* Class = "NSTextFieldCell"; title = "Indent width:"; ObjectID = "3287"; */
+"3287.title" = "以";
+/* Class = "NSTextFieldCell"; title = "spaces"; ObjectID = "as9-us-CuG"; */
+"as9-us-CuG.title" = "個空格縮排";
+/* Class = "NSButtonCell"; title = "Detect indent style on document opening"; ObjectID = "Cte-hW-0M3"; */
+"Cte-hW-0M3.title" = "在開啟文件時檢測縮排格式";
+/* Class = "NSButtonCell"; title = "Indent selection with Tab key"; ObjectID = "aVn-PD-hen"; */
+"aVn-PD-hen.title" = "使用Tab鍵對選擇進行縮排";
+
+
+/* Class = "NSTextFieldCell"; title = "Line wrapping:"; ObjectID = "P1I-gs-RgX"; */
+"P1I-gs-RgX.title" = "換行：";
+/* Class = "NSButtonCell"; title = "Wrap lines to editor width"; ObjectID = "3274"; */
+"3274.title" = "換行以適合編輯器寬度";
+/* Class = "NSButtonCell"; title = "Indent wrapped lines by:"; ObjectID = "mCq-92-2sT"; */
+"mCq-92-2sT.title" = "自動換行縮排字元數：";
+/* Class = "NSTextFieldCell"; title = "spaces"; ObjectID = "P9V-pV-PAX"; */
+"P9V-pV-PAX.title" = "個空格";
+
+
+/* Class = "NSTextFieldCell"; title = "Comment:"; ObjectID = "EDl-AJ-1dK"; */
+"EDl-AJ-1dK.title" = "註釋：";
+/* Class = "NSButtonCell"; title = "Append a space to comment delimiter"; ObjectID = "6Dw-5M-Gv0"; */
+"6Dw-5M-Gv0.title" = "在註釋符號後追加空格";
+/* Class = "NSButtonCell"; title = "Always from line head"; ObjectID = "Byi-E9-owf"; */
+"Byi-E9-owf.title" = "使用從行首開始";
+
+
+/* Class = "NSTextFieldCell"; title = "Completion:"; ObjectID = "gDN-SU-sZH"; */
+"gDN-SU-sZH.title" = "補全：";
+
+/* Class = "NSTextFieldCell"; title = "Completion list includes:"; ObjectID = "dLj-Kh-KtX"; */
+"dLj-Kh-KtX.title" = "補全列表包括：";
+/* Class = "NSButtonCell"; title = "Words in document"; ObjectID = "EJZ-N6-54G"; */
+"EJZ-N6-54G.title" = "文件中的單詞";
+/* Class = "NSButtonCell"; title = "Words defined in syntax style"; ObjectID = "1v9-7i-9RL"; */
+"1v9-7i-9RL.title" = "文法樣式中包含的單詞";
+/* Class = "NSButtonCell"; title = "Standard words"; ObjectID = "c5j-0N-f2R"; */
+"c5j-0N-f2R.title" = "標準單詞";
+
+/* Class = "NSButtonCell"; title = "Suggest completions while typing"; ObjectID = "J1B-wA-rdr"; */
+"J1B-wA-rdr.title" = "忽略字串中的製表符和換行符";
+
+/* Class = "NSTextFieldCell"; title = "⚠️ Select at least one item to enable completion."; ObjectID = "dmb-pc-4M5"; */
+"dmb-pc-4M5.title" = "⚠️ 至少選擇一個條目來啟用補全。";

--- a/CotEditor/zh-Hant.lproj/EditorView.strings
+++ b/CotEditor/zh-Hant.lproj/EditorView.strings
@@ -1,0 +1,38 @@
+//
+//  EditorView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSButton"; ibShadowedToolTip = "Jump to previous outline item"; ObjectID = "BUj-TD-scp"; */
+"BUj-TD-scp.ibShadowedToolTip" = "上一個提綱條目";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Jump to next outline item"; ObjectID = "MlW-Dz-FOk"; */
+"MlW-Dz-FOk.ibShadowedToolTip" = "下一個提綱條目";
+
+
+/* Class = "NSButton"; ibShadowedToolTip = "Close split editor"; ObjectID = "Bmo-XE-CCn"; */
+"Bmo-XE-CCn.ibShadowedToolTip" = "關閉分欄編輯器";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Split editor"; ObjectID = "syK-XU-x2I"; */
+"syK-XU-x2I.ibShadowedToolTip" = "分欄顯示";

--- a/CotEditor/zh-Hant.lproj/EncodingListView.strings
+++ b/CotEditor/zh-Hant.lproj/EncodingListView.strings
@@ -1,0 +1,43 @@
+//
+//  EncodingListView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2020 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Drag encodings to change the order:"; ObjectID = "3395"; */
+"3395.title" = "拖拽以改變編碼順序：";
+
+/* Class = "NSButtonCell"; title = "Add Separator"; ObjectID = "3392"; */
+"3392.title" = "新增分隔線";
+/* Class = "NSButtonCell"; title = "Delete Separator"; ObjectID = "3393"; */
+"3393.title" = "刪除分隔線";
+
+/* Class = "NSTextFieldCell"; title = "This order is for the encoding menu and the encoding detection on file opening. By the detection, the higher items are more prioritized."; ObjectID = "3394"; */
+"3394.title" = "這個列表是為編碼選單中的自動檢測準備的。\n透過檢測，較高的條目將獲得較高的優先順序。";
+
+/* Class = "NSButtonCell"; title = "Restore Defaults"; ObjectID = "3396"; */
+"3396.title" = "恢復預設";
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "3390"; */
+"3390.title" = "取消";
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "3391"; */
+"3391.title" = "好";

--- a/CotEditor/zh-Hant.lproj/FileDropPane.strings
+++ b/CotEditor/zh-Hant.lproj/FileDropPane.strings
@@ -1,0 +1,59 @@
+//
+//  FileDropPane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "File Drop Definitions:"; ObjectID = "3331"; */
+"3331.title" = "檔案拖拽定義：";
+
+/* Class = "NSTableColumn"; headerCell.title = "Extensions"; ObjectID = "FAF-cL-AAk"; */
+"FAF-cL-AAk.headerCell.title" = "副檔名";
+"FAF-cL-AAk.headerToolTip" = "拖拽檔案的副檔名 (逗號分隔)。";  /* Filename extensions of dropped file (comma separated). */
+
+/* Class = "NSTableColumn"; headerCell.title = "Syntax Style"; ObjectID = "RqT-x4-YbN"; */
+"RqT-x4-YbN.headerCell.title" = "文法樣式";
+"RqT-x4-YbN.headerToolTip" = "文法樣式中的檔案拖拽設定已啟用";  /* Syntax style in which this file drop setting is enabled. */
+
+/* Class = "NSTableColumn"; headerCell.title = "Description"; ObjectID = "p2m-Qi-6k3"; */
+"p2m-Qi-6k3.headerCell.title" = "描述";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "All"; ObjectID = "hY5-0z-qN6"; */
+"hY5-0z-qN6.ibShadowedIsNilPlaceholder" = "全部";  // displays if no scope extension is specified
+/* Class = "NSMenuItem"; title = "All"; ObjectID = "W3Z-PB-IUJ"; */
+"W3Z-PB-IUJ.title" = "全部";  // displays if no scope syntax style is specified
+
+/* Class = "NSSegmentedCell"; oXA-8G-UhH.ibShadowedToolTips[0] = "Add"; ObjectID = "oXA-8G-UhH"; */
+"oXA-8G-UhH.ibShadowedToolTips[0]" = "新增";
+/* Class = "NSSegmentedCell"; oXA-8G-UhH.ibShadowedToolTips[1] = "Delete"; ObjectID = "oXA-8G-UhH"; */
+"oXA-8G-UhH.ibShadowedToolTips[1]" = "刪除";
+
+
+/* Class = "NSTextFieldCell"; title = "Insertion Format:"; ObjectID = "3332"; */
+"3332.title" = "按格式插入：";
+
+/* Class = "NSMenuItem"; title = "Insert Variable"; ObjectID = "541"; */
+"541.title" = "插入變數";
+
+/* Class = "IBBindingConnection"; ibShadowedNoSelectionPlaceholder = "No extension is selected."; ObjectID = "ib2-Zw-Ucy"; */
+"ib2-Zw-Ucy.ibShadowedNoSelectionPlaceholder" = "沒有選中副檔名。";

--- a/CotEditor/zh-Hant.lproj/FindPanel.strings
+++ b/CotEditor/zh-Hant.lproj/FindPanel.strings
@@ -1,0 +1,119 @@
+//
+//  FindPanel.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2015-01-06.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2015-2016 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// Find Panel
+
+/* Class = "NSPanel"; title = "Find & Replace"; ObjectID = "Wal-Sg-6d6"; */
+"Wal-Sg-6d6.title" = "查詢 & 替換";
+
+/* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Find"; ObjectID = "3sL-0v-4Cy"; */
+"3sL-0v-4Cy.ibShadowedIsNilPlaceholder" = "查詢";
+/* Class = "NSTextView"; ibShadowedToolTip = "Type the text to search for."; ObjectID = "hxw-DS-gxQ"; */
+"hxw-DS-gxQ.ibShadowedToolTip" = "輸入要查詢的文字。";
+/* Class = "NSTextView"; ibExternalAccessibilityDescription = "Find"; ObjectID = "hxw-DS-gxQ"; */
+"hxw-DS-gxQ.ibExternalAccessibilityDescription" = "查詢";
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Clear"; ObjectID = "ObJ-nS-x0g"; */
+"ObJ-nS-x0g.ibExternalAccessibilityDescription" = "清除";
+
+/* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Replace"; ObjectID = "VUA-ld-ABD"; */
+"VUA-ld-ABD.ibShadowedIsNilPlaceholder" = "替換";
+/* Class = "NSTextView"; ibShadowedToolTip = "Type the text to replace the found text."; ObjectID = "qiQ-tb-XCa"; */
+"qiQ-tb-XCa.ibShadowedToolTip" = "輸入用來替換查詢到的文字。";
+/* Class = "NSTextView"; ibExternalAccessibilityDescription = "Replace"; ObjectID = "qiQ-tb-XCa"; */
+"qiQ-tb-XCa.ibExternalAccessibilityDescription" = "替換";
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Clear"; ObjectID = "Y5M-CG-n0V"; */
+"Y5M-CG-n0V.ibExternalAccessibilityDescription" = "清除";
+
+/* Class = "NSButtonCell"; title = "Regular Expression"; ObjectID = "brT-HP-GVL"; */
+"brT-HP-GVL.title" = "正規表示式";
+/* Class = "NSButton"; ibShadowedToolTip = "Select to search with regular expression."; ObjectID = "8My-G5-daT"; */
+"8My-G5-daT.ibShadowedToolTip" = "選中以啟用正規表示式查詢。";
+
+/* Class = "NSButtonCell"; title = "Ignore Case"; ObjectID = "4wg-Cz-ozb"; */
+"4wg-Cz-ozb.title" = "忽略大小寫";
+/* Class = "NSButton"; ibShadowedToolTip = "Select to ignore character case on search."; ObjectID = "GvT-tD-Cbk"; */
+"GvT-tD-Cbk.ibShadowedToolTip" = "選中以忽略大小寫。";
+
+/* Class = "NSButtonCell"; title = "In Selection"; ObjectID = "9bc-9Q-fhd"; */
+"9bc-9Q-fhd.title" = "選中範圍內";
+/* Class = "NSButton"; ibShadowedToolTip = "Select to search text only from selection."; ObjectID = "tu7-IT-dA3"; */
+"tu7-IT-dA3.ibShadowedToolTip" = "選中僅在選擇範圍內進行文字查詢。";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Show quick reference for regular expression syntax."; ObjectID = "i2l-7Z-Zmf"; */
+"i2l-7Z-Zmf.ibShadowedToolTip" = "顯示正規表示式快速參考。";
+
+
+// Buttons
+
+/* Class = "NSButtonCell"; title = "Find All"; ObjectID = "XLZ-92-VVF"; */
+"XLZ-92-VVF.title" = "查詢全部";
+/* Class = "NSButton"; ibShadowedToolTip = "Find and list up all matches."; ObjectID = "OCv-Y5-8XR"; */
+"OCv-Y5-8XR.ibShadowedToolTip" = "列出所有匹配。";
+
+/* Class = "NSButtonCell"; title = "Replace All"; ObjectID = "5gU-5y-iLn"; */
+"5gU-5y-iLn.title" = "替換全部";
+/* Class = "NSButton"; ibShadowedToolTip = "Replace all matches with the replacement text."; ObjectID = "RR6-rj-B8P"; */
+"RR6-rj-B8P.ibShadowedToolTip" = "將所有匹配用替換文字替換。";
+
+/* Class = "NSButtonCell"; title = "Replace"; ObjectID = "W4Z-S2-wvv"; */
+"W4Z-S2-wvv.title" = "替換";
+// Note: The tooltip for "Replace button is set the in FindPanelController.
+
+/* Class = "NSSegmentedCell"; ObjectID = "u6p-Hz-aK5"; */
+"u6p-Hz-aK5.ibShadowedToolTips[0]" = "查詢前一個匹配。";  /* "Find previous match." */
+"u6p-Hz-aK5.ibShadowedToolTips[1]" = "查詢後一個匹配。";  /* "Find next match." */
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Recent Searches"; ObjectID = "3ZH-bg-rl5"; */
+"3ZH-bg-rl5.ibExternalAccessibilityDescription" = "最近查詢";
+/* Class = "NSMenuItem"; title = "Recent Searches"; ObjectID = "cdV-rY-hCN"; */
+"cdV-rY-hCN.title" = "最近查詢";
+/* Class = "NSMenuItem"; title = "Clear Recent Searches"; ObjectID = "vE8-oK-xlC"; */
+"vE8-oK-xlC.title" = "清除最近查詢";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Recent Replacements"; ObjectID = "Hw7-zz-RG8"; */
+"Hw7-zz-RG8.ibExternalAccessibilityDescription" = "最近替換";
+/* Class = "NSMenuItem"; title = "Recent Replacements"; ObjectID = "7cw-iQ-0LM"; */
+"7cw-iQ-0LM.title" = "最近替換";
+/* Class = "NSMenuItem"; title = "Clear Recent Replacements"; ObjectID = "vfK-an-Qnl"; */
+"vfK-an-Qnl.title" = "清除最近替換";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Set advanced options"; ObjectID = "ESq-ws-6H3"; */
+"ESq-ws-6H3.ibShadowedToolTip" = "設定高階選項";
+"ESq-ws-6H3.ibExternalAccessibilityDescription" = "高階選項";
+
+
+// Find Result
+
+/* Class = "NSButton"; UeN.ibShadowedToolTip = "Close find result."; ObjectID = "oC1-bN-UeN"; */
+"oC1-bN-UeN.ibShadowedToolTip" = "關閉查詢結果。";
+
+/* Class = "BindingConnection"; ibShadowedDisplayPattern = "Find String: %{value1}@"; ObjectID = "2MH-SD-x1y"; */
+"2MH-SD-x1y.ibShadowedDisplayPattern" = "查詢字串：%{value1}@";
+
+/* Class = "NSTableColumn"; headerCell.title = "Line"; ObjectID = "CPd-0W-bKv"; */
+"CPd-0W-bKv.headerCell.title" = "行";
+/* Class = "NSTableColumn"; headerCell.title = "Found String"; ObjectID = "PJ8-wp-pdK"; */
+"PJ8-wp-pdK.headerCell.title" = "找到字串";

--- a/CotEditor/zh-Hant.lproj/FindPreferencesView.strings
+++ b/CotEditor/zh-Hant.lproj/FindPreferencesView.strings
@@ -1,0 +1,88 @@
+//
+//  FindPreferencesView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2016-01-24.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2015-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Advanced Find Options"; ObjectID = "Dl6-kv-hhz"; */
+"Dl6-kv-hhz.title" = "高階查詢選項";
+
+
+/* Class = "NSButtonCell"; title = "Wrap search around"; ObjectID = "o7S-uI-urg"; */
+"o7S-uI-urg.title" = "折行查詢";
+/* Class = "NSButtonCell"; title = "Select next match after replace"; ObjectID = "XBp-LE-3Ry"; */
+"XBp-LE-3Ry.title" = "替換後選擇下一個匹配";
+/* Class = "NSButtonCell"; title = "Auto-close progress dialog"; ObjectID = "KBq-zH-H2M"; */
+"KBq-zH-H2M.title" = "自動關閉進度表";
+
+
+// Textual Search
+
+/* Class = "NSTextFieldCell"; title = "Textual Search"; ObjectID = "d1L-6X-N8c"; */
+"d1L-6X-N8c.title" = "文字查詢";
+
+/* Class = "NSButtonCell"; title = "Match only whole word"; ObjectID = "Na3-Ur-cf8"; */
+"Na3-Ur-cf8.title" = "僅全字匹配";
+/* Class = "NSButton"; ibShadowedToolTip = "Restrict search results to the whole words."; ObjectID = "eqE-mg-d9b"; */
+"eqE-mg-d9b.ibShadowedToolTip" = "將查詢結果限定於全字。";
+
+/* Class = "NSButtonCell"; title = "Distinguish characters strictly"; ObjectID = "mY4-am-wla"; */
+"mY4-am-wla.title" = "嚴格區分字元";
+/* Class = "NSButton"; ibShadowedToolTip = "Exact character-by-character equivalence."; ObjectID = "KG4-LQ-sen"; */
+"KG4-LQ-sen.ibShadowedToolTip" = "逐字元相等查詢";
+
+/* Class = "NSButtonCell"; title = "Ignore diacritical marks"; ObjectID = "OUc-5d-N7I"; */
+"OUc-5d-N7I.title" = "忽略變音符號";
+/* Class = "NSButton"; ibShadowedToolTip = "Search Ignore diacritical marks (e.g., ö = o)."; ObjectID = "YYY-qb-T00"; */
+"YYY-qb-T00.ibShadowedToolTip" = "忽略變音符號進行查詢 (例如ö = o)。";
+
+/* Class = "NSButtonCell"; title = "Ignores width differences"; ObjectID = "Jug-Dk-JMZ"; */
+"Jug-Dk-JMZ.title" = "忽略字元寬度";
+/* Class = "NSButton"; ibShadowedToolTip = "Search ignores width differences in character forms (e.g., ａ = a)."; ObjectID = "A5O-jt-o7T"; */
+"A5O-jt-o7T.ibShadowedToolTip" = "忽略字元形式的寬度進行查詢 (例如ａ = a)。";
+
+
+// Regular Expression
+
+/* Class = "NSTextFieldCell"; title = "Regular Expression Search"; ObjectID = "Xa9-i4-ELR"; */
+"Xa9-i4-ELR.title" = "正規表示式查詢";
+
+/* Class = "NSButtonCell"; title = "Dot matches line separators"; ObjectID = "nqr-AM-oJQ"; */
+"nqr-AM-oJQ.title" = "使點匹配換行";
+/* Class = "NSButton"; ibShadowedToolTip = "Allow . to match any character, including newline characters (singleline)."; ObjectID = "c11-J5-UXF"; */
+"c11-J5-UXF.ibShadowedToolTip" = "允許.匹配包括 (單行) 換行符在內的任意字元。";
+
+/* Class = "NSButtonCell"; title = "Anchors match lines"; ObjectID = "YXU-NA-BZb"; */
+"YXU-NA-BZb.title" = "使錨點匹配行";
+/* Class = "NSButton"; ibShadowedToolTip = "Allow ^ and $ to match the start and end of lines (multiline)."; ObjectID = "Lhw-9C-lgB"; */
+"Lhw-9C-lgB.ibShadowedToolTip" = "允許^和$匹配 (多行的) 行首和行尾。";
+
+/* Class = "NSButtonCell"; title = "Use Unicode word boundaries"; ObjectID = "5oj-ch-YiX"; */
+"5oj-ch-YiX.title" = "使用Unicode字詞邊界";
+/* Class = "NSButton"; ibShadowedToolTip = "Use Unicode TR#29 to specify word boundaries"; ObjectID = "VMh-Tq-bq0"; */
+"VMh-Tq-bq0.ibShadowedToolTip" = "使用Unicode TR#29指定字詞邊界";
+
+/* Class = "NSButtonCell"; title = "Unescape replacement string"; ObjectID = "rTR-zE-Wff"; */
+"rTR-zE-Wff.title" = "解碼替換字串";
+/* Class = "NSButton"; ibShadowedToolTip = "Unescape meta characters with backslash in replacement string."; ObjectID = "PLV-vr-cdI"; */
+"PLV-vr-cdI.ibShadowedToolTip" = "使用反斜槓元字元解碼替換字串";

--- a/CotEditor/zh-Hant.lproj/FormatPane.strings
+++ b/CotEditor/zh-Hant.lproj/FormatPane.strings
@@ -1,0 +1,92 @@
+//
+//  FormatPane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Default line endings:"; ObjectID = "3273"; */
+"3273.title" = "預設行尾：";
+/* Class = "NSMenuItem"; title = "macOS / Unix (LF)"; ObjectID = "15"; */
+"15.title" = "macOS / Unix (LF)";
+/* Class = "NSMenuItem"; title = "Classic Mac OS (CR)"; ObjectID = "14"; */
+"14.title" = "Classic Mac OS (CR)";
+/* Class = "NSMenuItem"; title = "Windows (CRLF)"; ObjectID = "12"; */
+"12.title" = "Windows (CRLF)";
+
+
+/* Class = "NSTextFieldCell"; title = "Default text encoding:"; ObjectID = "3278"; */
+"3278.title" = "預設文字編碼：";
+
+/* Class = "NSTextFieldCell"; title = "Priority of encodings:"; ObjectID = "3277"; */
+"3277.title" = "編碼優先順序：";
+/* Class = "NSButtonCell"; title = "Edit List…"; ObjectID = "3275"; */
+"3275.title" = "編輯列表…";
+/* Class = "NSButtonCell"; title = "Refer to encoding declaration in document"; ObjectID = "3280"; */
+"3280.title" = "參考文件中的編碼宣告";
+
+
+
+/* Class = "NSButtonCell"; title = "Enable syntax highlighting"; ObjectID = "3326"; */
+"3326.title" = "啟用文法高亮";
+/* Class = "NSTextFieldCell"; title = "(Including outline extraction)"; ObjectID = "3325"; */
+"3325.title" = "（包括大綱提取）";
+
+/* Class = "NSTextFieldCell"; title = "Default syntax style:"; ObjectID = "3329"; */
+"3329.title" = "預設文法樣式：";
+
+/* Class = "NSTextFieldCell"; title = "Available syntax styles:"; ObjectID = "vlw-Tc-sLl"; */
+"vlw-Tc-sLl.title" = "可用的文法樣式：";
+
+/* Class = "NSView"; ibShadowedToolTip = "This style is customized."; ObjectID = "cbJ-XK-bnG"; */
+"cbJ-XK-bnG.ibShadowedToolTip" = "該樣式已被自定義。";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Remove selected style"; ObjectID = "dI1-Dk-Mce"; */
+"dI1-Dk-Mce.ibShadowedToolTip" = "移除選中的樣式";
+/* Class = "NSButton"; ibShadowedToolTip = "Add empty style"; ObjectID = "Hma-8v-2gu"; */
+"Hma-8v-2gu.ibShadowedToolTip" = "新增新的樣式";
+/* Class = "NSButton"; ibShadowedToolTip = "Edit selected style"; ObjectID = "Q0c-oI-um3"; */
+"Q0c-oI-um3.ibShadowedToolTip" = "編輯選中樣式";
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Edit"; ObjectID = "Q0c-oI-um3"; */
+"Q0c-oI-um3.ibExternalAccessibilityDescription" = "編輯";
+
+/* Class = "NSMenuItem"; title = "Import…"; ObjectID = "1lj-x8-ouD"; */
+"1lj-x8-ouD.title" = "匯入…";
+/* Class = "NSButtonCell"; title = "Reload All Styles"; ObjectID = "FhP-Hj-cWE"; */
+"FhP-Hj-cWE.title" = "過載全部樣式";
+/* Class = "NSMenuItem"; title = "Show File Mapping Conflicts"; ObjectID = "hyN-4W-57i"; */
+"hyN-4W-57i.title" = "顯示檔案對映衝突";
+
+
+/* contextual menu */
+/* Class = "NSMenuItem"; title = "Edit…"; ObjectID = "371-P0-KPK"; */
+"371-P0-KPK.title" = "編輯…";
+/* Class = "NSMenuItem"; title = "Duplicate…"; ObjectID = "5oN-VC-ot9"; */
+"5oN-VC-ot9.title" = "複製…";
+/* Class = "NSMenuItem"; title = "Restore"; ObjectID = "Zox-Ve-mru"; */
+"Zox-Ve-mru.title" = "還原";
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "NDE-r5-xAF"; */
+"NDE-r5-xAF.title" = "刪除";
+/* Class = "NSMenuItem"; title = "Export…"; ObjectID = "Qwp-u8-Urf"; */
+"Qwp-u8-Urf.title" = "匯出…";
+/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "AkE-0P-0FC"; */
+"AkE-0P-0FC.title" = "在訪達中顯示";

--- a/CotEditor/zh-Hant.lproj/GeneralPane.strings
+++ b/CotEditor/zh-Hant.lproj/GeneralPane.strings
@@ -1,0 +1,102 @@
+//
+//  GeneralPane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "On startup:"; ObjectID = "zDW-aW-9G8"; */
+"zDW-aW-9G8.title" = "啟動時：";
+
+/* Class = "NSButtonCell"; title = "Reopen windows from last session"; ObjectID = "QX9-BI-SIL"; */
+"QX9-BI-SIL.title" = "重新開啟上次會話的視窗";
+/* Class = "NSTextFieldCell"; title = "When nothing else is open:"; ObjectID = "wmw-xg-bSt"; */
+"wmw-xg-bSt.title" = "當沒有可以開啟的檔案時：";
+
+/* Class = "NSMenuItem"; title = "Create New Document"; ObjectID = "i4c-DG-ADS"; */
+"i4c-DG-ADS.title" = "建立新文件";
+/* Class = "NSMenuItem"; title = "Show Open Dialog"; ObjectID = "hIX-mh-cG4"; */
+"hIX-mh-cG4.title" = "顯示開啟對話方塊";
+/* Class = "NSMenuItem"; title = "Do Nothing"; ObjectID = "KgD-GV-alV"; */
+"KgD-GV-alV.title" = "不執行任何操作";
+
+
+/* Class = "NSTextFieldCell"; title = "Document save:"; ObjectID = "Ki4-3Y-AZL"; */
+"Ki4-3Y-AZL.title" = "文件儲存：";
+
+/* Class = "NSButtonCell"; title = "Enable Auto Save with Versions"; ObjectID = "SGo-FL-Pax"; */
+"SGo-FL-Pax.title" = "開啟帶有版本的自動儲存";
+/* Class = "NSTextFieldCell"; title = "A system feature that automatically overwrites your files while editing. Even if it turned off, CotEditor creates backup covertly for unexpected quit."; ObjectID = "sOa-Ea-zt9"; */
+"sOa-Ea-zt9.title" = "編輯檔案時自動覆蓋儲存檔案的系統特性。即使被禁用，CotEditor也會在程式退出時自動儲存備份。";
+
+
+/* Class = "NSTextFieldCell"; title = "When document is changed by another application:"; ObjectID = "x4n-2n-I3p"; */
+"x4n-2n-I3p.title" = "當文件被其他應用更改時：";
+
+/* Class = "NSButtonCell"; title = "Keep CotEditor’s edition"; ObjectID = "sBH-MX-cTd"; */
+"sBH-MX-cTd.title" = "保留CotEditor的版本";
+/* Class = "NSButtonCell"; title = "Ask how to resolve"; ObjectID = "IkZ-EO-BSv"; */
+"IkZ-EO-BSv.title" = "詢問如何更新";
+/* Class = "NSButtonCell"; title = "Update to modified edition"; ObjectID = "rpa-Di-f4s"; */
+"rpa-Di-f4s.title" = "更新到被更改的版本";
+
+
+/* Class = "NSTextFieldCell"; title = "Content parse:"; ObjectID = "lzy-Ei-xlT"; */
+"lzy-Ei-xlT.title" = "內容解析:";
+
+/* Class = "NSButtonCell"; title = "Ignore line endings when counting characters"; ObjectID = "3306"; */
+"3306.title" = "字元計數時忽略行尾";
+/* Class = "NSButtonCell"; title = "Link URLs in document"; ObjectID = "tPy-Ox-YpP"; */
+"tPy-Ox-YpP.title" = "連結文件中的 URL";
+/* Class = "NSButtonCell"; title = "Check spelling while typing"; ObjectID = "3300"; */
+"3300.title" = "輸入時檢查拼寫";
+/* Class = "NSButtonCell"; title = "Highlight matching braces “()” “[]” “{}”"; ObjectID = "RrC-LL-hid"; */
+"RrC-LL-hid.title" = "高亮配對括弧“()” “[]” “{}”";
+/* Class = "NSButtonCell"; title = "Highlight “<>”"; ObjectID = "al9-WE-Rqy"; */
+"al9-WE-Rqy.title" = "高亮“<>”";
+/* Class = "NSButtonCell"; title = "Highlight instances of selected text"; ObjectID = "Rcq-1K-8nz"; */
+"Rcq-1K-8nz.title" = "高亮選中文字";
+/* Class = "NSTextFieldCell"; title = "Delay:"; ObjectID = "rOw-DD-kV5"; */
+"rOw-DD-kV5.title" = "延遲：";
+/* Class = "NSTextFieldCell"; title = "seconds"; ObjectID = "ebJ-vk-RME"; */
+"ebJ-vk-RME.title" = "秒";
+
+
+/* Class = "NSTextFieldCell"; title = "Command-line tool:"; ObjectID = "kQn-Uu-cqG"; */
+"kQn-Uu-cqG.title" = "命令列工具：";
+/* Class = "NSButtonCell"; title = "Learn More…"; ObjectID = "ltN-wn-m8M"; */
+"ltN-wn-m8M.title" = "瞭解更多…";
+/* Class = "NSTextFieldCell"; title = "With the 'cot' command-line tool, you can launch CotEditor and let it open files from the command line."; ObjectID = "c48-xK-Ag1"; */
+"c48-xK-Ag1.title" = "cot 命令列工具可以讓您使用命令列來啟動CotEditor並開啟檔案。";
+
+
+/* Class = "NSTextFieldCell"; title = "Software update:"; ObjectID = "geU-63-sAC"; */
+"geU-63-sAC.title" = "軟體更新：";
+
+/* Class = "NSButtonCell"; title = "Check for updates automatically"; ObjectID = "3423"; */
+"3423.title" = "自動檢查更新";
+
+/* Class = "NSButtonCell"; title = "Update to pre-releases when available"; ObjectID = "4aT-ka-sbv"; */
+"4aT-ka-sbv.title" = "包含預釋出版本";
+
+/* Class = "NSButtonCell"; title = "Regardless of this setting, new pre-releases are always included while using a pre-release."; ObjectID = "chR-VY-cuI"; */
+"chR-VY-cuI.title" = "在預釋出版本中，無論該選項如何設定，總是會更新到新的預釋出版本。";

--- a/CotEditor/zh-Hant.lproj/GoToLineView.strings
+++ b/CotEditor/zh-Hant.lproj/GoToLineView.strings
@@ -1,0 +1,39 @@
+//
+//  GoToLineView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2016-06-07.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2016 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Line:"; ObjectID = "R30-Wf-Rfd"; */
+"R30-Wf-Rfd.title" = "行：";
+
+/* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Line Number"; ObjectID = "yIX-ZF-8vP"; */
+"yIX-ZF-8vP.ibShadowedIsNilPlaceholder" = "行號";
+
+/* Class = "NSTextFieldCell"; placeholderString = "Line Number"; ObjectID = "F6K-QJ-Ox1"; */
+"F6K-QJ-Ox1.placeholderString" = "行號";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "JUX-sh-0Ej"; */
+"JUX-sh-0Ej.title" = "取消";
+/* Class = "NSButtonCell"; title = "Go"; ObjectID = "cuJ-kD-yiJ"; */
+"cuJ-kD-yiJ.title" = "跳轉";

--- a/CotEditor/zh-Hant.lproj/KeyBindingsPane.strings
+++ b/CotEditor/zh-Hant.lproj/KeyBindingsPane.strings
@@ -1,0 +1,78 @@
+//
+//  KeyBindingsPane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSViewController"; title = "Menu Items"; ObjectID = "sBQ-LT-Rwm"; */
+"sBQ-LT-Rwm.title" = "選單項";
+/* Class = "NSViewController"; title = "Snippets"; ObjectID = "9kQ-W2-4kw"; */
+"9kQ-W2-4kw.title" = "程式碼片段";
+
+
+
+/* Class = "NSTextFieldCell"; title = "Shortcuts for menu items"; ObjectID = "ZYM-tb-Csx"; */
+"ZYM-tb-Csx.title" = "選單條目的快捷按鍵";
+
+/* Class = "NSTextFieldCell"; title = "(excluding Script menu)"; ObjectID = "Dl2-3y-7EJ"; */
+"Dl2-3y-7EJ.title" = "(不包括. 指令碼選單)";
+
+/* Class = "NSTextFieldCell"; title = "To change a binding, select it, click the key column, and then type the keys."; ObjectID = "Hue-bU-8wr"; */
+"Hue-bU-8wr.title" = "選中要繫結的條目並點一下按鍵列來改變繫結";
+
+/* Class = "NSTextFieldCell"; title = "The keys here must include the Command key."; ObjectID = "qGe-Et-FB2"; */
+"qGe-Et-FB2.title" = "快捷鍵中必須包含Command鍵。";
+
+/* Class = "NSTableColumn"; headerCell.title = "Action"; ObjectID = "jNh-nd-VRd"; */
+"jNh-nd-VRd.headerCell.title" = "動作";
+/* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "PSD-Um-TfH"; */
+"PSD-Um-TfH.headerCell.title" = "按鍵";
+
+/* Class = "NSButtonCell"; title = "Restore Defaults"; ObjectID = "CyK-OL-qHa"; */
+"CyK-OL-qHa.title" = "恢復預設";
+
+
+
+/* Class = "NSTextFieldCell"; title = "Shortcuts for preset text insertion"; ObjectID = "eMZ-Mx-JSK"; */
+"eMZ-Mx-JSK.title" = "插入預定義文字的快捷按鍵";
+
+/* Class = "NSTextFieldCell"; title = "To change a binding, select it, click the key column, and then type the keys."; ObjectID = "a9m-M2-rgC"; */
+"a9m-M2-rgC.title" = "選中要繫結的條目並點一下按鍵列來改變繫結";
+
+/* Class = "NSTextFieldCell"; title = "The keys here must exclude the Command key."; ObjectID = "5zd-aF-0zL"; */
+"5zd-aF-0zL.title" = "快捷鍵中不能包含Command鍵。";
+
+/* Class = "NSTableColumn"; headerCell.title = "Action"; ObjectID = "sz5-hl-bZK"; */
+"sz5-hl-bZK.headerCell.title" = "動作";
+/* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "hXU-bV-zlt"; */
+"hXU-bV-zlt.headerCell.title" = "按鍵";
+
+/* Class = "NSTextFieldCell"; title = "Insertion Format:"; ObjectID = "tuB-9O-QZH"; */
+"tuB-9O-QZH.title" = "按格式插入：";
+/* Class = "NSMenuItem"; title = "Insert Variable"; ObjectID = "wC4-qj-3oD"; */
+"wC4-qj-3oD.title" = "插入變數";
+/* Class = "CocoaBindingsConnection"; ibShadowedNoSelectionPlaceholder = "Select Action"; ObjectID = "Y5G-PR-ofT"; */
+"Y5G-PR-ofT.ibShadowedNoSelectionPlaceholder" = "選擇動作。";
+
+/* Class = "NSButtonCell"; title = "Restore Defaults"; ObjectID = "0Du-JI-ZN7"; */
+"0Du-JI-ZN7.title" = "恢復預設";

--- a/CotEditor/zh-Hant.lproj/Main.strings
+++ b/CotEditor/zh-Hant.lproj/Main.strings
@@ -1,0 +1,616 @@
+//
+//  Main.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// MARK: Dock Menu
+
+/* Class = "NSMenuItem"; title = "New"; ObjectID = "qTb-gl-0V3"; */
+"qTb-gl-0V3.title" = "新增檔案";
+/* Class = "NSMenuItem"; title = "Open…"; ObjectID = "I1W-t0-8TD"; */
+"I1W-t0-8TD.title" = "開啟檔案…";
+
+
+
+// MARK: CotEditor
+
+/* Class = "NSMenuItem"; title = "CotEditor"; ObjectID = "56"; */
+"56.title" = "CotEditor";
+/* Class = "NSMenu"; title = "CotEditor"; ObjectID = "57"; */
+"57.title" = "CotEditor";
+
+/* Class = "NSMenuItem"; title = "About CotEditor"; ObjectID = "58"; */
+"58.title" = "關於CotEditor";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "129"; */
+"129.title" = "偏好設定…";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "130"; */
+"130.title" = "服務";
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "131"; */
+"131.title" = "服務";
+
+/* Class = "NSMenuItem"; title = "Hide CotEditor"; ObjectID = "134"; */
+"134.title" = "隱藏 CotEditor";
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "145"; */
+"145.title" = "隱藏其他";
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "150"; */
+"150.title" = "全部顯示";
+
+/* Class = "NSMenuItem"; title = "Quit CotEditor"; ObjectID = "136"; */
+"136.title" = "退出 CotEditor";
+
+
+
+// MARK: File
+
+/* Class = "NSMenuItem"; title = "File"; ObjectID = "83"; */
+"83.title" = "檔案";
+/* Class = "NSMenu"; title = "File"; ObjectID = "81"; */
+"81.title" = "檔案";
+
+/* Class = "NSMenuItem"; title = "New"; ObjectID = "82"; */
+"82.title" = "新增";
+/* Class = "NSMenuItem"; title = "New Window"; ObjectID = "cTV-Rh-597"; */
+"cTV-Rh-597.title" = "新增視窗";
+/* Class = "NSMenuItem"; title = "New Tab"; ObjectID = "WCp-4v-OPR"; */
+"WCp-4v-OPR.title" = "新增標籤";
+/* Class = "NSMenuItem"; title = "Open…"; ObjectID = "72"; */
+"72.title" = "開啟檔案…";
+/* Class = "NSMenuItem"; title = "Open Recent"; ObjectID = "124"; */
+"124.title" = "開啟最近使用";
+/* Class = "NSMenu"; title = "Open Recent"; ObjectID = "125"; */
+"125.title" = "開啟最近使用";
+
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "73"; */
+"73.title" = "關閉";
+/* Class = "NSMenuItem"; title = "Save"; ObjectID = "75"; */
+"75.title" = "儲存";
+/* Class = "NSMenuItem"; title = "Save As…"; ObjectID = "80"; */
+"80.title" = "儲存為…";
+/* Class = "NSMenuItem"; title = "Revert to Saved"; ObjectID = "112"; */
+"112.title" = "復原到已儲存版本";
+
+/* Class = "NSMenuItem"; title = "Page Setup…"; ObjectID = "77"; */
+"77.title" = "頁面設定…";
+/* Class = "NSMenuItem"; title = "Print…"; ObjectID = "78"; */
+"78.title" = "列印…";
+
+
+
+// MARK: Edit
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "163"; */
+"163.title" = "編輯";
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "169"; */
+"169.title" = "編輯";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "158"; */
+"158.title" = "撤銷";
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "173"; */
+"173.title" = "重做";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "160"; */
+"160.title" = "剪下";
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "157"; */
+"157.title" = "複製";
+/* Class = "NSMenuItem"; title = "Copy as Rich Text"; ObjectID = "j3t-7l-xSy"; */
+"j3t-7l-xSy.title" = "以富文字複製";
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "171"; */
+"171.title" = "貼上";
+/* Class = "NSMenuItem"; title = "Paste Exactly"; ObjectID = "MTm-Qg-WjY"; */
+"MTm-Qg-WjY.title" = "精確貼上";
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "164"; */
+"164.title" = "刪除";
+/* Class = "NSMenuItem"; title = "Complete"; ObjectID = "Qa9-dA-CF1"; */
+"Qa9-dA-CF1.title" = "聯想";
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "172"; */
+"172.title" = "全選";
+/* Class = "NSMenuItem"; title = "Select Line"; ObjectID = "Cwp-ys-LJc"; */
+"Cwp-ys-LJc.title" = "選擇行";
+/* Class = "NSMenuItem"; title = "Select Word"; ObjectID = "0HX-j9-5jF"; */
+"0HX-j9-5jF.title" = "選擇單詞";
+
+/* Class = "NSMenuItem"; title = "Input Backslash"; ObjectID = "631"; */
+"631.title" = "輸入反斜槓";
+/* Class = "NSMenuItem"; title = "Input Yen Mark"; ObjectID = "633"; */
+"633.title" = "輸入日元符號";
+/* Class = "NSMenuItem"; title = "Input in Unicode Code Point…"; ObjectID = "tWx-pj-3PL"; */
+"tWx-pj-3PL.title" = "用 Unicode 輸入…";
+
+/* Class = "NSMenuItem"; title = "Spelling and Grammar"; ObjectID = "2QI-XD-7pJ"; */
+"2QI-XD-7pJ.title" = "拼寫和文法";
+/* Class = "NSMenu"; title = "Spelling and Grammar"; ObjectID = "rKZ-vK-0OH"; */
+"rKZ-vK-0OH.title" = "拼寫和文法";
+/* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "uXu-vF-RqZ"; */
+"uXu-vF-RqZ.title" = "顯示拼寫和文法";
+/* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "hIk-Nu-0X3"; */
+"hIk-Nu-0X3.title" = "立即檢查文稿";
+/* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "9ny-sN-pmO"; */
+"9ny-sN-pmO.title" = "輸入時檢查拼寫";
+/* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "5eg-wx-S4p"; */
+"5eg-wx-S4p.title" = "檢查拼寫和文法";
+/* Class = "NSMenuItem"; title = "Correct Spelling Automatically"; ObjectID = "kQ8-FM-Cgx"; */
+"kQ8-FM-Cgx.title" = "自動糾正拼寫";
+
+/* Class = "NSMenu"; title = "Substitutions"; ObjectID = "2wy-A5-6kZ"; */
+"2wy-A5-6kZ.title" = "替換";
+/* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "yN3-iT-4Lq"; */
+"yN3-iT-4Lq.title" = "替換";
+/* Class = "NSMenuItem"; title = "Replace Quotes"; ObjectID = "7NX-1r-Wq7"; */
+"7NX-1r-Wq7.title" = "替換引號";
+/* Class = "NSMenuItem"; title = "Straighten Quotes"; ObjectID = "9gl-1h-Yit"; */
+"9gl-1h-Yit.title" = "直引號";
+/* Class = "NSMenuItem"; title = "Replace Dashes"; ObjectID = "hMS-qd-BCS"; */
+"hMS-qd-BCS.title" = "替換破折號";
+/* Class = "NSMenuItem"; title = "Replace Text"; ObjectID = "ue7-85-H8l"; */
+"ue7-85-H8l.title" = "替換文字";
+/* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "gqI-2M-XIx"; */
+"gqI-2M-XIx.title" = "顯示替換";
+/* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "QKD-ue-EQp"; */
+"QKD-ue-EQp.title" = "智慧複製/貼上";
+/* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "sza-9T-f4h"; */
+"sza-9T-f4h.title" = "智慧引號";
+/* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "cIp-rb-QPk"; */
+"cIp-rb-QPk.title" = "智慧破折號";
+/* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "PSn-PG-o9k"; */
+"PSn-PG-o9k.title" = "文字替換";
+
+/* Class = "NSMenuItem"; title = "Speech"; ObjectID = "gBe-fO-wVv"; */
+"gBe-fO-wVv.title" = "語音";
+/* Class = "NSMenu"; title = "Speech"; ObjectID = "HZ8-G2-f8d"; */
+"HZ8-G2-f8d.title" = "語音";
+/* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "4mJ-DV-Qjz"; */
+"4mJ-DV-Qjz.title" = "開始朗讀";
+/* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "2rV-Ut-h4x"; */
+"2rV-Ut-h4x.title" = "停止朗讀";
+
+
+
+// MARK: Format
+
+/* Class = "NSMenuItem"; title = "Format"; ObjectID = "247"; */
+"247.title" = "格式";
+/* Class = "NSMenu"; title = "Format"; ObjectID = "246"; */
+"246.title" = "格式";
+
+/* Class = "NSMenuItem"; title = "Line Endings"; ObjectID = "294"; */
+"294.title" = "行尾";
+/* Class = "NSMenu"; title = "Line Endings"; ObjectID = "296"; */
+"296.title" = "行尾";
+/* Class = "NSMenuItem"; title = "macOS / Unix (LF)"; ObjectID = "295"; */
+"295.title" = "macOS / Unix (LF)";
+/* Class = "NSMenuItem"; title = "Classic Mac OS (CR)"; ObjectID = "297"; */
+"297.title" = "Classic Mac OS (CR)";
+/* Class = "NSMenuItem"; title = "Windows (CRLF)"; ObjectID = "298"; */
+"298.title" = "Windows (CRLF)";
+/* Class = "NSMenuItem"; title = "Next Line (NEL)"; ObjectID = "pUE-eY-9RI"; */
+"pUE-eY-9RI.title" = "下一行 (NEL)";  // Unlike other line endings, this item is preferably as-is because of the unfamiliarity.
+/* Class = "NSMenuItem"; title = "Unicode Line Separator (LS)"; ObjectID = "ins-89-nu3"; */
+"ins-89-nu3.title" = "萬國碼分行標記 (LS)";  // Unlike other line endings, this item is preferably as-is because of the unfamiliarity.
+/* Class = "NSMenuItem"; title = "Unicode Paragraph Separator (PS)"; ObjectID = "Zz9-5c-bS1"; */
+"Zz9-5c-bS1.title" = "萬國碼分段標記 (PS)";  // Unlike other line endings, this item is preferably as-is because of the unfamiliarity.
+
+/* Class = "NSMenuItem"; title = "File Encoding"; ObjectID = "299"; */
+"299.title" = "檔案編碼";
+/* Class = "NSMenu"; title = "File Encoding"; ObjectID = "300"; */
+"300.title" = "檔案編碼";
+
+/* Class = "NSMenuItem"; title = "Syntax Style"; ObjectID = "302"; */
+"302.title" = "文法樣式";
+/* Class = "NSMenu"; title = "Syntax Style"; ObjectID = "304"; */
+"304.title" = "文法樣式";
+/* Class = "NSMenuItem"; title = "Recolor All"; ObjectID = 458; */
+"458.title" = "全部重新著色";
+
+/* Class = "NSMenuItem"; title = "Font"; ObjectID = "410"; */
+"410.title" = "字型";
+/* Class = "NSMenu"; title = "Font"; ObjectID = "418"; */
+"418.title" = "字型";
+
+/* Class = "NSMenuItem"; title = "Show Fonts"; ObjectID = "424"; */
+"424.title" = "顯示字型";
+/* Class = "NSMenuItem"; title = "Bigger"; ObjectID = "405"; */
+"405.title" = "較大";
+/* Class = "NSMenuItem"; title = "Smaller"; ObjectID = "404"; */
+"404.title" = "較小";
+/* Class = "NSMenuItem"; title = "Reset to Default"; ObjectID = "574"; */
+"574.title" = "重置";
+/* Class = "NSMenuItem"; title = "Anti-aliasing"; ObjectID = "745"; */
+"745.title" = "抗鋸齒";
+/* Class = "NSMenuItem"; title = "Ligatures"; ObjectID = "viH-Eo-wKz"; */
+"viH-Eo-wKz.title" = "連字";
+
+/* Class = "NSMenuItem"; title = "Tab Width"; ObjectID = "djM-fI-MkN"; */
+"djM-fI-MkN.title" = "Tab寬度";
+/* Class = "NSMenu"; title = "Tab Width"; ObjectID = "xAm-b4-9CY"; */
+"xAm-b4-9CY.title" = "Tab寬度";
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "qs3-we-YzU"; */
+"qs3-we-YzU.title" = "2";
+/* Class = "NSMenuItem"; title = "3"; ObjectID = "8hL-SQ-WlX"; */
+"8hL-SQ-WlX.title" = "3";
+/* Class = "NSMenuItem"; title = "4"; ObjectID = "fwb-zD-hBp"; */
+"fwb-zD-hBp.title" = "4";
+/* Class = "NSMenuItem"; title = "8"; ObjectID = "9e0-Q5-Oqh"; */
+"9e0-Q5-Oqh.title" = "8";
+/* Class = "NSMenuItem"; title = "Custom…"; ObjectID = "gMO-5n-fiJ"; */
+"gMO-5n-fiJ.title" = "自定義…";
+/* Class = "NSMenuItem"; title = "Auto-Expand Tabs"; ObjectID = "hsG-8k-OKX"; */
+"hsG-8k-OKX.title" = "Tab轉為空格";
+
+/* Class = "NSMenuItem"; title = "Show Invisibles"; ObjectID = "788"; */
+"788.title" = "顯示不可見元素";
+/* Class = "NSMenuItem"; title = "Show Indent Guides"; ObjectID = "Qqu-pI-Xz6"; */
+"Qqu-pI-Xz6.title" = "顯示縮排指示";
+/* Class = "NSMenuItem"; title = "Show Page Guide"; ObjectID = "749"; */
+"749.title" = "顯示頁面指示";
+
+/* Class = "NSMenuItem"; title = "Writing Direction"; ObjectID = "mEh-BD-ZlV"; */
+"mEh-BD-ZlV.title" = "書寫方向";
+/* Class = "NSMenu"; title = "Writing Direction"; ObjectID = "hxr-2A-KYT"; */
+"hxr-2A-KYT.title" = "書寫方向";
+/* Class = "NSMenuItem"; title = "Orientation"; ObjectID = "6eV-nI-heo"; */
+"6eV-nI-heo.title" = "方位";
+/* Class = "NSMenuItem"; title = "Horizontal"; ObjectID = "jQ7-hG-AjA"; */
+"jQ7-hG-AjA.title" = "水平";
+/* Class = "NSMenuItem"; title = "Vertical"; ObjectID = "bTd-nG-jjc"; */
+"bTd-nG-jjc.title" = "豎直";
+/* Class = "NSMenuItem"; title = "Direction"; ObjectID = "ICu-yD-nVi"; */
+"ICu-yD-nVi.title" = "方向";
+/* Class = "NSMenuItem"; title = "Left to Right"; ObjectID = "7pw-5S-ekC"; */
+"7pw-5S-ekC.title" = "從左到右";
+/* Class = "NSMenuItem"; title = "Right to Left"; ObjectID = "clG-Ph-Iyz"; */
+"clG-Ph-Iyz.title" = "從右到左";
+
+/* Class = "NSMenuItem"; title = "Wrap Lines"; ObjectID = "286"; */
+"286.title" = "換行";
+
+/* Class = "NSMenuItem"; title = "Theme"; ObjectID = "8z7-Jc-agP"; */
+"8z7-Jc-agP.title" = "主題";
+/* Class = "NSMenu"; title = "Theme"; ObjectID = "165-HJ-Xty"; */
+"165-HJ-Xty.title" = "主題";
+
+
+
+// MARK: View
+
+/* Class = "NSMenuItem"; title = "View"; ObjectID = "322"; */
+"322.title" = "顯示";
+/* Class = "NSMenu"; title = "View"; ObjectID = "324"; */
+"324.title" = "顯示";
+
+/* Class = "NSMenuItem"; title = "Hide Toolbar"; ObjectID = "612"; */
+"612.title" = "隱藏工具欄";
+/* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "613"; */
+"613.title" = "自定工具欄…";
+
+
+/* Class = "NSMenuItem"; title = "Inspector"; ObjectID = "sYa-2o-iPk"; */
+"sYa-2o-iPk.title" = "檢查器";
+/* Class = "NSMenu"; title = "Inspector"; ObjectID = "10j-rd-fWr"; */
+"10j-rd-fWr.title" = "檢查器";
+/* Class = "NSMenuItem"; title = "Document Inspector"; ObjectID = "564"; */
+"564.title" = "文稿資訊";
+/* Class = "NSMenuItem"; title = "Outline"; ObjectID = "Gch-XD-tRl"; */
+"Gch-XD-tRl.title" = "大綱";
+/* Class = "NSMenuItem"; title = "Warnings"; ObjectID = "679"; */
+"679.title" = "警告";
+/* Class = "NSMenuItem"; title = "Show Inspector"; ObjectID = "I2p-KB-gxR"; */
+"I2p-KB-gxR.title" = "顯示檢查器";
+
+/* Class = "NSMenuItem"; title = "Show Navigation Bar"; ObjectID = "681"; */
+"681.title" = "顯示導航欄";
+/* Class = "NSMenuItem"; title = "Show Line Numbers"; ObjectID = "323"; */
+"323.title" = "顯示行號";
+/* Class = "NSMenuItem"; title = "Show Status Bar"; ObjectID = "325"; */
+"325.title" = "顯示狀態列";
+
+/* Class = "NSMenuItem"; title = "Split Editor"; ObjectID = "793"; */
+"793.title" = "分欄顯示";
+/* Class = "NSMenuItem"; title = "Focus on Next Split Editor"; ObjectID = "794"; */
+"794.title" = "焦點下一個分欄編輯器";
+/* Class = "NSMenuItem"; title = "Focus on Previous Split Editor"; ObjectID = "795"; */
+"795.title" = "焦點前一個分欄編輯器";
+/* Class = "NSMenuItem"; title = "Stack Editors Vertically"; ObjectID = "u46-te-4c4"; */
+"u46-te-4c4.title" = "縱向分欄顯示";
+/* Class = "NSMenuItem"; title = "Close Split Editor"; ObjectID = "796"; */
+"796.title" = "關閉分欄顯示";
+
+/* Class = "NSMenuItem"; title = "Change Editor’s Opacity…"; ObjectID = "367"; */
+"367.title" = "更改編輯器透明度…";
+
+/* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "2da-fK-Nkg"; */
+"2da-fK-Nkg.title" = "進入全屏";
+
+
+
+// MARK: Text
+
+/* Class = "NSMenu"; title = "Text"; ObjectID = "578"; */
+"578.title" = "文字";
+/* Class = "NSMenuItem"; title = "Text"; ObjectID = "579"; */
+"579.title" = "文字";
+
+/* Class = "NSMenuItem"; title = "Comment"; ObjectID = "EYa-d3-sUR"; */
+"EYa-d3-sUR.title" = "註釋";
+/* Class = "NSMenu"; title = "Comment"; ObjectID = "yph-qH-qNE"; */
+"yph-qH-qNE.title" = "註釋";
+/* Class = "NSMenuItem"; title = "Toggle Comment"; ObjectID = "LLy-Yx-tXI"; */
+"LLy-Yx-tXI.title" = "切換註釋";
+/* Class = "NSMenuItem"; title = "Inline Comment"; ObjectID = "F6P-7N-LSf"; */
+"F6P-7N-LSf.title" = "行註釋";
+/* Class = "NSMenuItem"; title = "Block Comment"; ObjectID = "U5v-4k-2tq"; */
+"U5v-4k-2tq.title" = "塊註釋";
+/* Class = "NSMenuItem"; title = "Uncomment"; ObjectID = "dob-yj-jf3"; */
+"dob-yj-jf3.title" = "取消註釋";
+
+/* Class = "NSMenuItem"; title = "Indentation"; ObjectID = "4h9-iu-ehP"; */
+"4h9-iu-ehP.title" = "縮排";
+/* Class = "NSMenu"; title = "Indentation"; ObjectID = "YOd-Hk-eIa"; */
+"YOd-Hk-eIa.title" = "縮排";
+/* Class = "NSMenuItem"; title = "Shift Right"; ObjectID = "454"; */
+"454.title" = "右移";
+/* Class = "NSMenuItem"; title = "Shift Left"; ObjectID = "455"; */
+"455.title" = "左移";
+/* Class = "NSMenuItem"; title = "Convert Indentation to Spaces"; ObjectID = "EOT-3u-f0a"; */
+"EOT-3u-f0a.title" = "將縮排轉換為空格";
+/* Class = "NSMenuItem"; title = "Convert Indentation to Tabs"; ObjectID = "q32-Jm-eR3"; */
+"q32-Jm-eR3.title" = "將縮排轉換為Tab";
+
+/* Class = "NSMenuItem"; title = "Lines"; ObjectID = "Kb8-QD-tYZ"; */
+"Kb8-QD-tYZ.title" = "行";
+/* Class = "NSMenu"; title = "Lines"; ObjectID = "BSD-be-CV9"; */
+"BSD-be-CV9.title" = "行";
+/* Class = "NSMenuItem"; title = "Move Up"; ObjectID = "4t7-IA-1r3"; */
+"4t7-IA-1r3.title" = "上移";
+/* Class = "NSMenuItem"; title = "Move Down"; ObjectID = "J59-OR-kzC"; */
+"J59-OR-kzC.title" = "下移";
+/* Class = "NSMenuItem"; title = "Sort"; ObjectID = "OQl-Uo-yfn"; */
+"OQl-Uo-yfn.title" = "排序";
+/* Class = "NSMenuItem"; title = "Sort by Pattern…"; ObjectID = "lNH-Mh-pIE"; */
+"lNH-Mh-pIE.title" = "按模式排序…";
+/* Class = "NSMenuItem"; title = "Reverse"; ObjectID = "xhf-NR-D2Q"; */
+"xhf-NR-D2Q.title" = "逆向排序";
+/* Class = "NSMenuItem"; title = "Delete Duplicates"; ObjectID = "bjv-m0-tZq"; */
+"bjv-m0-tZq.title" = "刪除重複";
+/* Class = "NSMenuItem"; title = "Duplicate Line"; ObjectID = "m48-5E-yia"; */
+"m48-5E-yia.title" = "複製行";
+/* Class = "NSMenuItem"; title = "Delete Line"; ObjectID = "sFn-3j-pY5"; */
+"sFn-3j-pY5.title" = "刪除行";
+
+/* Class = "NSMenuItem"; title = "Surround Selection With"; ObjectID = "9dv-Zb-W60"; */
+"9dv-Zb-W60.title" = "將選擇進行環繞";
+/* Class = "NSMenu"; title = "Surround Selection With"; ObjectID = "AUq-CT-rPl"; */
+"AUq-CT-rPl.title" = "將選擇進行環繞";
+/* Class = "NSMenuItem"; title = "Single Quotes"; ObjectID = "Srp-eD-10Q"; */
+"Srp-eD-10Q.title" = "單引號";
+/* Class = "NSMenuItem"; title = "Double Quotes"; ObjectID = "O8z-C9-ECD"; */
+"O8z-C9-ECD.title" = "雙引號";
+/* Class = "NSMenuItem"; title = "Parentheses"; ObjectID = "G3o-1h-GwR"; */
+"G3o-1h-GwR.title" = "圓括弧";  // ()
+/* Class = "NSMenuItem"; title = "Braces"; ObjectID = "Xoq-43-C1z"; */
+"Xoq-43-C1z.title" = "大括弧";  // {}
+/* Class = "NSMenuItem"; title = "Brackets"; ObjectID = "cTU-2P-7Tp"; */
+"cTU-2P-7Tp.title" = "方括弧";  // []
+/* Class = "NSMenuItem"; title = "Custom…"; ObjectID = "3VX-DL-PgT"; */
+"3VX-DL-PgT.title" = "自定義…";
+
+/* Class = "NSMenuItem"; title = "Trim Trailing Whitespace"; ObjectID = "hBJ-Ge-278"; */
+"hBJ-Ge-278.title" = "移除行尾空白";
+
+/* Class = "NSMenuItem"; title = "Transformations"; ObjectID = "GXo-ds-ygp"; */
+"GXo-ds-ygp.title" = "轉換";
+/* Class = "NSMenu"; title = "Transformations"; ObjectID = "b36-nH-7po"; */
+"b36-nH-7po.title" = "轉換";
+
+/* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "RX2-gg-n33"; */
+"RX2-gg-n33.title" = "變為大寫";
+/* Class = "NSMenuItem"; title = "Make Lower Case"; ObjectID = "ZrR-aL-1eB"; */
+"ZrR-aL-1eB.title" = "變為小寫";
+/* Class = "NSMenuItem"; title = "Capitalize"; ObjectID = "LC4-lg-eO0"; */
+"LC4-lg-eO0.title" = "首字母大寫";
+
+/* Class = "NSMenuItem"; title = "Make Snake Case"; ObjectID = "F0I-F4-srF"; */
+"F0I-F4-srF.title" = "轉為蛇形式";
+/* Class = "NSMenuItem"; title = "Make Camel Case"; ObjectID = "nlp-Gj-W9G"; */
+"nlp-Gj-W9G.title" = "轉為小駝峰式";
+/* Class = "NSMenuItem"; title = "Make Pascal Case"; ObjectID = "x1F-KX-2de"; */
+"x1F-KX-2de.title" = "轉為大駝峰式";
+
+/* Class = "NSMenuItem"; title = "Half-width to Full-width"; ObjectID = "dVK-1s-xJq"; */
+"dVK-1s-xJq.title" = "半寬到全寬";
+/* Class = "NSMenuItem"; title = "Full-width to Half-width"; ObjectID = "Skr-vI-7VN"; */
+"Skr-vI-7VN.title" = "全寬到半寬";
+/* Class = "NSMenuItem"; title = "ASCII to Full-width ASCII"; ObjectID = "586"; */
+"586.title" = "ASCII 到全寬 ASCII";
+/* Class = "NSMenuItem"; title = "Full-width ASCII to ASCII"; ObjectID = "588"; */
+"588.title" = "全寬 ASCII 到 ASCII";
+
+/* Class = "NSMenuItem"; title = "Japanese Text"; ObjectID = "XWV-by-mnw"; */
+"XWV-by-mnw.title" = "日文文字";
+/* Class = "NSMenuItem"; title = "Hiragana to Katakana"; ObjectID = "592"; */
+"592.title" = "平假名到片假名";
+/* Class = "NSMenuItem"; title = "Katakana to Hiragana"; ObjectID = "594"; */
+"594.title" = "片假名到平假名";
+
+/* Class = "NSMenu"; title = "Unicode Normalizations"; ObjectID = "600"; */
+"600.title" = "Unicode 標準化";
+/* Class = "NSMenuItem"; title = "Unicode Normalizations"; ObjectID = "599"; */
+"599.title" = "Unicode 標準化";
+
+/* Class = "NSMenuItem"; title = "NFD"; ObjectID = "601"; */
+"601.title" = "NFD";
+/* Class = "NSMenuItem"; title = "Canonical Decomposition"; ObjectID = "601"; */
+"601.ibShadowedToolTip" = "以標準等價方式來分解";
+/* Class = "NSMenuItem"; title = "NFC"; ObjectID = "602"; */
+"602.title" = "NFC";
+/* Class = "NSMenuItem"; title = "Canonical Decomposition, followed by Canonical Composition"; ObjectID = "602"; */
+"602.ibShadowedToolTip" = "以標準等價方式來分解，然後以標準等價重組之";
+/* Class = "NSMenuItem"; title = "NFKD"; ObjectID = "603"; */
+"603.title" = "NFKD";
+/* Class = "NSMenuItem"; title = "Compatibility Decomposition"; ObjectID = "603"; */
+"603.ibShadowedToolTip" = "以相容等價方式來分解";
+/* Class = "NSMenuItem"; title = "NFKC"; ObjectID = "598"; */
+"598.title" = "NFKC";
+/* Class = "NSMenuItem"; title = "Compatibility Decomposition, followed by Canonical Composition"; ObjectID = "598"; */
+"598.ibShadowedToolTip" = "以相容等價方式來分解，然後以標準等價重組之";
+/* Class = "NSMenuItem"; title = "NFKC Casefold"; ObjectID = "zuR-3K-9fs"; */
+"zuR-3K-9fs.title" = "NFKC Casefold";
+/* Class = "NSMenuItem"; title = "Applying NFKC, CaseFolding, and removal of default-ignorable code points"; ObjectID = "zuR-3K-9fs"; */
+"zuR-3K-9fs.ibShadowedToolTip" = "正在NFKC, CaseFolding, 並移除預設可忽略編碼點";
+/* Class = "NSMenuItem"; title = "Modified NFD (HFS+)"; ObjectID = "NU7-EI-1Ct"; */
+"NU7-EI-1Ct.title" = "修改NFD (HFS+)";
+/* Class = "NSMenuItem"; title = "Unofficial NFD-based normalization form used in HFS+"; ObjectID = "NU7-EI-1Ct"; */
+"NU7-EI-1Ct.ibShadowedToolTip" = "在HFS+中使用了非官方的基於NFD的標準化形式。";
+/* Class = "NSMenuItem"; title = "Modified NFC (HFS+)"; ObjectID = "n6C-Km-BM9"; */
+"n6C-Km-BM9.title" = "修改NFC (HFS+)";
+/* Class = "NSMenuItem"; title = "Unofficial NFC-based normalization form corresponding to Modified NFD"; ObjectID = "n6C-Km-BM9"; */
+"n6C-Km-BM9.ibShadowedToolTip" = "非官方的基於NFD的標準化形式與修改後的NFD對應";
+
+/* Class = "NSMenuItem"; title = "Insert Encoding Name"; ObjectID = "663"; */
+"663.title" = "插入編碼名字";
+/* Class = "NSMenuItem"; title = "Insert encoding name as IANA charset"; ObjectID = "663"; */
+"663.ibShadowedToolTip" = "插入作為IANA字符集的編碼名字";
+
+/* Class = "NSMenuItem"; title = "Inspect Character"; ObjectID = "ToR-yH-ahH"; */
+"ToR-yH-ahH.title" = "檢視文字";
+/* Class = "NSMenuItem"; title = "Edit Color Code…"; ObjectID = "641"; */
+"641.title" = "編輯顏色程式碼…";
+
+
+
+// MARK: Find
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "538"; */
+"538.title" = "查詢";
+/* Class = "NSMenu"; title = "Find"; ObjectID = "kGA-vM-cdL"; */
+"kGA-vM-cdL.title" = "查詢";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "eP6-ss-sUG"; */
+"eP6-ss-sUG.title" = "查詢…";
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "NwE-Cf-L9F"; */
+"NwE-Cf-L9F.title" = "查詢下一個";
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "wiV-Hh-7xU"; */
+"wiV-Hh-7xU.title" = "查詢上一個";
+/* Class = "NSMenuItem"; title = "Find Selected Text"; ObjectID = "l33-Nz-UAw"; */
+"l33-Nz-UAw.title" = "在選擇文字中查詢";
+/* Class = "NSMenuItem"; title = "Find All"; ObjectID = "HgR-ke-6gq"; */
+"HgR-ke-6gq.title" = "查詢全部";
+/* Class = "NSMenuItem"; title = "Select All Find Matches"; ObjectID = "ULf-cT-Xvb"; */
+"ULf-cT-Xvb.title" = "選擇全部查詢到的匹配";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "hTx-ef-3T2"; */
+"hTx-ef-3T2.title" = "查詢所選內容";
+/* Class = "NSMenuItem"; title = "Use Selection for Replace"; ObjectID = "kwa-lu-0Fz"; */
+"kwa-lu-0Fz.title" = "替換所選內容";
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "p4A-mE-Ve3"; */
+"p4A-mE-Ve3.title" = "跳到所選內容";
+
+/* Class = "NSMenuItem"; title = "Replace"; ObjectID = "bnD-BP-sPi"; */
+"bnD-BP-sPi.title" = "替換";
+/* Class = "NSMenuItem"; title = "Replace and Find Next"; ObjectID = "KrV-3z-r5B"; */
+"KrV-3z-r5B.title" = "替換並查詢下一個";
+/* Class = "NSMenuItem"; title = "Replace All"; ObjectID = "5HV-xo-NTK"; */
+"5HV-xo-NTK.title" = "替換全部";
+/* Class = "NSMenuItem"; title = "Multiple Replace…"; ObjectID = "o7K-sI-KJA"; */
+"o7K-sI-KJA.title" = "多重替換…";
+
+/* Class = "NSMenuItem"; title = "Highlight"; ObjectID = "JAO-3o-fRo"; */
+"JAO-3o-fRo.title" = "高亮";
+/* Class = "NSMenuItem"; title = "Unhighlight"; ObjectID = "5is-7G-OVT"; */
+"5is-7G-OVT.title" = "取消高亮";
+
+/* Class = "NSMenuItem"; title = "Open Outline Menu"; ObjectID = "PmT-ho-UU7"; */
+"PmT-ho-UU7.title" = "開啟大綱選單";
+/* Class = "NSMenuItem"; title = "Select Previous Outline Item"; ObjectID = "9Lf-39-x5S"; */
+"9Lf-39-x5S.title" = "選擇上一個大綱條目";
+/* Class = "NSMenuItem"; title = "Select Next Outline Item"; ObjectID = "PWZ-Om-OhX"; */
+"PWZ-Om-OhX.title" = "選擇下一個大綱條目";
+
+/* Class = "NSMenuItem"; title = "Go to Line…"; ObjectID = "eIc-Sj-2mO"; */
+"eIc-Sj-2mO.title" = "跳轉到行…";
+
+
+
+// MARK: Window
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "19"; */
+"19.title" = "視窗";
+/* Class = "NSMenu"; title = "Window"; ObjectID = "24"; */
+"24.title" = "視窗";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "23"; */
+"23.title" = "最小化";
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "203"; */
+"203.title" = "縮放";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "5"; */
+"5.title" = "前置全部視窗";
+
+/* Class = "NSMenuItem"; title = "Console"; ObjectID = "653"; */
+"653.title" = "主控台";
+
+
+
+// MARK: Script
+
+/* Class = "NSMenu"; title = "Script"; ObjectID = "616"; */
+"616.title" = "指令碼";
+/* Class = "NSMenuItem"; title = "Script"; ObjectID = "617"; */
+"617.title" = "指令碼";
+
+
+
+// MARK: Help
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "103"; */
+"103.title" = "幫助";
+/* Class = "NSMenu"; title = "Help"; ObjectID = "106"; */
+"106.title" = "幫助";
+
+/* Class = "NSMenuItem"; title = "CotEditor Help"; ObjectID = "111"; */
+"111.title" = "CotEditor 幫助";
+
+/* Class = "NSMenuItem"; title = "CotEditor Scripting Guide"; ObjectID = "M1N-Fg-Bo4"; */
+"M1N-Fg-Bo4.title" = "CotEditor 指令碼手冊";
+/* Class = "NSMenu"; title = "CotEditor Scripting Guide"; ObjectID = "OLa-Mb-rXS"; */
+"OLa-Mb-rXS.title" = "CotEditor 指令碼手冊";
+/* Class = "NSMenuItem"; title = "About Scripting"; ObjectID = "u2o-8v-WPL"; */
+"u2o-8v-WPL.title" = "關於指令碼";
+/* Class = "NSMenuItem"; title = "AppleScript Dictionary"; ObjectID = "620"; */
+"620.title" = "AppleScript 字典";
+
+/* Class = "NSMenuItem"; title = "Release Notes"; ObjectID = "822"; */
+"822.title" = "釋出說明";
+/* Class = "NSMenuItem"; title = "What’s New in CotEditor"; ObjectID = "DCW-Ij-540"; */
+"DCW-Ij-540.title" = "CotEditor 新特性";
+/* Class = "NSMenuItem"; title = "Acknowledgments"; ObjectID = "824"; */
+"824.title" = "致謝";
+
+/* Class = "NSMenuItem"; title = "Create Issue Report"; ObjectID = "iHn-Ed-A8u"; */
+"iHn-Ed-A8u.title" = "建立問題報告";
+/* Class = "NSMenuItem"; title = "Report Issue"; ObjectID = "Bk3-xx-uft"; */
+"Bk3-xx-uft.title" = "報告問題";
+/* Class = "NSMenuItem"; title = "CotEditor Website"; ObjectID = "g34-YV-E6o"; */
+"g34-YV-E6o.title" = "CotEditor 網站";

--- a/CotEditor/zh-Hant.lproj/MultipleReplacementPanel.strings
+++ b/CotEditor/zh-Hant.lproj/MultipleReplacementPanel.strings
@@ -1,0 +1,175 @@
+//
+//  MultipleReplacementPanel.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2018-05-08.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ---------------------------------------------------------------------------
+//
+//  © 2018-2022 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSWindow"; title = "Multiple Replace"; ObjectID = "rFC-87-Fxd"; */
+"rFC-87-Fxd.title" = "多重替換";
+
+
+
+// MARK: Content list
+
+/* Class = "NSMenuItem"; title = "Duplicate"; ObjectID = "mF9-q3-LmX"; */
+"mF9-q3-LmX.title" = "複製";
+/* Class = "NSMenuItem"; title = "Rename"; ObjectID = "cZ9-i9-VsM"; */
+"cZ9-i9-VsM.title" = "重新命名";
+/* Class = "NSMenuItem"; title = "Export…"; ObjectID = "fN1-Tr-8T8"; */
+"fN1-Tr-8T8.title" = "匯入…";
+/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "tLz-9S-3we"; */
+"tLz-9S-3we.title" = "在訪達中顯示";
+/* Class = "NSMenuItem"; title = "Import…"; ObjectID = "iZn-Pw-tgJ"; */
+"iZn-Pw-tgJ.title" = "匯出…";
+/* Class = "NSMenuItem"; title = "Reload All Definitions"; ObjectID = "0ca-Jy-pHT"; */
+"0ca-Jy-pHT.title" = "過載全部定義";
+
+/* Class = "NSMenuItem"; title = "New Definition"; ObjectID = "ah0-d7-MIb"; */
+"ah0-d7-MIb.title" = "新增定義";
+/* Class = "NSMenuItem"; title = "Duplicate"; ObjectID = "zRC-iK-Noh"; */
+"zRC-iK-Noh.title" = "複製";
+/* Class = "NSMenuItem"; title = "Rename"; ObjectID = "KGb-Yh-gXR"; */
+"KGb-Yh-gXR.title" = "重新命名";
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "M9A-ds-FNR"; */
+"M9A-ds-FNR.title" = "刪除";
+/* Class = "NSMenuItem"; title = "Export…"; ObjectID = "5mf-DX-YT5"; */
+"5mf-DX-YT5.title" = "匯入…";
+/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "sYx-dd-JiV"; */
+"sYx-dd-JiV.title" = "在訪達中顯示";
+/* Class = "NSMenuItem"; title = "Import…"; ObjectID = "8TG-QH-hxz"; */
+"8TG-QH-hxz.title" = "匯出…";
+
+
+
+// MARK: Editor View
+
+/* Class = "NSTextFieldCell"; title = "Perform replacement using these rules in succession from the top down:"; ObjectID = "5Ey-vx-5Sm"; */
+"5Ey-vx-5Sm.title" = "使用這些規則從上至下連續進行替換:";
+
+
+/* Class = "NSTableColumn"; headerToolTip = "Enable"; ObjectID = "KTe-1r-oHM"; */
+"KTe-1r-oHM.headerToolTip" = "啟用";
+/* Class = "NSButton"; ibShadowedToolTip = "Select to enable this replacement rule."; ObjectID = "PuQ-No-wC1"; */
+"PuQ-No-wC1.ibShadowedToolTip" = "選擇以啟用該替換規則。";
+
+/* Class = "NSTableColumn"; headerCell.title = "Find"; ObjectID = "zee-UW-TVR"; */
+"zee-UW-TVR.headerCell.title" = "查詢";
+
+/* Class = "NSTableColumn"; headerCell.title = "Replace With"; ObjectID = "nRC-aM-NZ2"; */
+"nRC-aM-NZ2.headerCell.title" = "替換";
+
+/* Class = "NSTableColumn"; headerCell.title = "RE"; ObjectID = "VtR-Qz-MBf"; */
+"VtR-Qz-MBf.headerCell.title" = "RE";
+/* Class = "NSTableColumn"; headerToolTip = "Regular Expression"; ObjectID = "VtR-Qz-MBf"; */
+"VtR-Qz-MBf.headerToolTip" = "正規表示式";
+
+/* Class = "NSTableColumn"; headerCell.title = "IC"; ObjectID = "d3o-yf-jB4"; */
+"d3o-yf-jB4.headerCell.title" = "IC";
+/* Class = "NSTableColumn"; headerToolTip = "Ignore Cases"; ObjectID = "d3o-yf-jB4"; */
+"d3o-yf-jB4.headerToolTip" = "忽略大小寫";
+
+/* Class = "NSTableColumn"; headerCell.title = "Description"; ObjectID = "Rhy-iE-CIC"; */
+"Rhy-iE-CIC.headerCell.title" = "描述";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Select to search with regular expression."; ObjectID = "Lk4-Ym-IrV"; */
+"Lk4-Ym-IrV.ibShadowedToolTip" = "選中以啟用正規表示式查詢。";
+/* Class = "NSButton"; ibShadowedToolTip = "Select to ignore character case on search."; ObjectID = "I23-3I-yq5"; */
+"I23-3I-yq5.ibShadowedToolTip" = "選中以忽略大小寫。";
+
+
+/* Class = "NSTextFieldCell"; title = "Invalid rules will be skipped."; ObjectID = "gRf-KM-GZo"; */
+"gRf-KM-GZo.title" = "無效的規則將被跳過。";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Set advanced options"; ObjectID = "i8z-Xa-PxI"; */
+"i8z-Xa-PxI.ibShadowedToolTip" = "設定高階選項";
+"i8z-Xa-PxI.ibExternalAccessibilityDescription" = "高階選項";
+
+
+/* Class = "NSButtonCell"; title = "In Selection"; ObjectID = "4lm-Fu-Fcf"; */
+"4lm-Fu-Fcf.title" = "選中範圍內";
+/* Class = "NSButton"; ibShadowedToolTip = "Select to replace text only in selection."; ObjectID = "pfM-xk-MrN"; */
+"pfM-xk-MrN.ibShadowedToolTip" = "選中僅在選擇範圍內進行文字查詢。";
+
+/* Class = "NSButtonCell"; title = "Highlight"; ObjectID = "kdu-Ni-M64"; */
+"kdu-Ni-M64.title" = "高亮";
+/* Class = "NSButton"; ibShadowedToolTip = "Highlight all matches of the replacement rules."; ObjectID = "99C-Bz-ySi"; */
+"99C-Bz-ySi.ibShadowedToolTip" = "高亮所有匹配替換規則的文字。";
+
+/* Class = "NSButtonCell"; title = "Replace All"; ObjectID = "LI2-Hh-D6g"; */
+"LI2-Hh-D6g.title" = "替換全部";
+/* Class = "NSButton"; ibShadowedToolTip = "Replace all matches according to the replacement rules."; ObjectID = "Nth-za-4Ad"; */
+"Nth-za-4Ad.ibShadowedToolTip" = "依據替換規則替換所有匹配文字。";
+
+
+
+// MARK: Advanced Find Options
+
+/* Class = "NSTextFieldCell"; title = "Advanced Find Options"; ObjectID = "NTu-fa-URI"; */
+"NTu-fa-URI.title" = "高階查詢選項";
+
+/* Class = "NSTextFieldCell"; title = "Textual Search"; ObjectID = "GU2-Em-4lt"; */
+"GU2-Em-4lt.title" = "文字查詢";
+
+/* Class = "NSButtonCell"; title = "Match only whole word"; ObjectID = "u12-3x-Oy6"; */
+"u12-3x-Oy6.title" = "僅全字匹配";
+/* Class = "NSButton"; ibShadowedToolTip = "Restrict search results to the whole words."; ObjectID = "lEO-tC-9zj"; */
+"lEO-tC-9zj.ibShadowedToolTip" = "將查詢結果限定於全字。";
+
+/* Class = "NSButtonCell"; title = "Distinguish characters strictly"; ObjectID = "tv3-0Q-m6B"; */
+"tv3-0Q-m6B.title" = "嚴格區分字元";
+/* Class = "NSButton"; ibShadowedToolTip = "Exact character-by-character equivalence."; ObjectID = "JiF-TN-azJ"; */
+"JiF-TN-azJ.ibShadowedToolTip" = "逐字元相等查詢";
+
+/* Class = "NSButtonCell"; title = "Ignore diacritical marks"; ObjectID = "WWu-mC-MCz"; */
+"WWu-mC-MCz.title" = "忽略變音符號";
+/* Class = "NSButton"; ibShadowedToolTip = "Search ignores diacritical marks (ex. ö = o)."; ObjectID = "9pO-Jw-K7x"; */
+"9pO-Jw-K7x.ibShadowedToolTip" = "忽略變音符號進行查詢 (例如ö = o)。";
+
+/* Class = "NSButtonCell"; title = "Ignore width differences"; ObjectID = "lVk-We-BSj"; */
+"lVk-We-BSj.title" = "忽略字元寬度";
+/* Class = "NSButton"; ibShadowedToolTip = "Search ignores width differences in character forms (ex. ａ = a)."; ObjectID = "6W5-EH-kOg"; */
+"6W5-EH-kOg.ibShadowedToolTip" = "忽略字元形式的寬度進行查詢 (例如ａ = a)。";
+
+
+/* Class = "NSTextFieldCell"; title = "Regular Expression Search"; ObjectID = "eCk-TH-lBA"; */
+"eCk-TH-lBA.title" = "正規表示式查詢";
+
+/* Class = "NSButtonCell"; title = "Dot matches line separators"; ObjectID = "ECw-cb-2hw"; */
+"ECw-cb-2hw.title" = "使點匹配換行";
+/* Class = "NSButton"; ibShadowedToolTip = "Allow . to match any character, including newline characters (singleline)."; ObjectID = "p1M-ap-Sov"; */
+"p1M-ap-Sov.ibShadowedToolTip" = "允許.匹配包括 (單行) 換行符在內的任意字元。";
+
+/* Class = "NSButtonCell"; title = "Anchors match lines"; ObjectID = "MJB-08-ddn"; */
+"MJB-08-ddn.title" = "使錨點匹配行";
+/* Class = "NSButton"; ibShadowedToolTip = "Allow ^ and $ to match the start and end of lines (multiline)."; ObjectID = "MvV-de-6ru"; */
+"MvV-de-6ru.ibShadowedToolTip" = "允許^和$匹配 (多行的) 行首和行尾。";
+
+/* Class = "NSButtonCell"; title = "Use Unicode word boundaries"; ObjectID = "8PD-6z-H5u"; */
+"8PD-6z-H5u.title" = "使用Unicode字詞邊界";
+/* Class = "NSButton"; ibShadowedToolTip = "Use Unicode TR#29 to specify word boundaries"; ObjectID = "6HK-St-iDw"; */
+"6HK-St-iDw.ibShadowedToolTip" = "使用Unicode TR#29指定字詞邊界";
+
+/* Class = "NSButtonCell"; title = "Unescape replacement string"; ObjectID = "1sB-Qy-Kw8"; */
+"1sB-Qy-Kw8.title" = "解碼替換字串";
+/* Class = "NSButton"; ibShadowedToolTip = "Unescape meta characters with backslash in replacement string."; ObjectID = "QRo-Az-lq4"; */
+"QRo-Az-lq4.ibShadowedToolTip" = "使用反斜槓元字元解碼替換字串";

--- a/CotEditor/zh-Hant.lproj/OpenDocumentAccessory.strings
+++ b/CotEditor/zh-Hant.lproj/OpenDocumentAccessory.strings
@@ -1,0 +1,31 @@
+//
+//  OpenDocumentAccessory.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2016 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Encoding:"; ObjectID = "voE-Mi-XZu"; */
+"voE-Mi-XZu.title" = "編碼：";
+
+/* Class = "NSButtonCell"; title = "Show hidden files"; ObjectID = "qkm-VD-lQC"; */
+"qkm-VD-lQC.title" = "顯示隱藏檔案";

--- a/CotEditor/zh-Hant.lproj/OutlineView.strings
+++ b/CotEditor/zh-Hant.lproj/OutlineView.strings
@@ -1,0 +1,34 @@
+//
+//  OutlineView.swift (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2018-02-27.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ---------------------------------------------------------------------------
+//
+//  © 2018-2022 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTableColumn"; headerCell.title = "Title"; ObjectID = "CSX-H0-nFf"; */
+"CSX-H0-nFf.headerCell.title" = "標題";
+
+/* Class = "NSTextFieldCell"; title = "Outline"; ObjectID = "RyV-wo-tpY"; */
+"RyV-wo-tpY.title" = "大綱";
+
+/* Class = "NSSearchFieldCell"; placeholderString = "Filter"; ObjectID = "GmM-uR-pQ8"; */
+"GmM-uR-pQ8.placeholderString" = "濾波器";

--- a/CotEditor/zh-Hant.lproj/PatternSortView.strings
+++ b/CotEditor/zh-Hant.lproj/PatternSortView.strings
@@ -1,0 +1,76 @@
+//
+//  PatternSortView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2018-01-05.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2018-2022 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Sample:"; ObjectID = "I06-xc-WQt"; */
+"I06-xc-WQt.title" = "示例：";
+/* Class = "NSTextField"; ibShadowedToolTip = "Sample line to check which part in a line will be used for sort comparison."; ObjectID = "W2m-Jf-7Yj"; */
+"W2m-Jf-7Yj.ibShadowedToolTip" = "檢查行中哪個部分將被用於比較排序的示例行。";
+
+/* Class = "NSTextFieldCell"; title = "Sort key:"; ObjectID = "bKb-oj-ekR"; */
+"bKb-oj-ekR.title" = "排序鍵：";
+
+/* Class = "NSButtonCell"; title = "Entire line"; ObjectID = "roe-rP-gfg"; */
+"roe-rP-gfg.title" = "整行";
+/* Class = "NSButtonCell"; title = "Column"; ObjectID = "pKE-GY-bD6"; */
+"pKE-GY-bD6.title" = "列";
+/* Class = "NSButtonCell"; title = "Regular expression"; ObjectID = "Ase-N7-QHB"; */
+"Ase-N7-QHB.title" = "正規表示式";
+
+
+/* Class = "NSTextFieldCell"; title = "Sort option:"; ObjectID = "eio-Wb-V6q"; */
+"eio-Wb-V6q.title" = "排序選項：";
+/* Class = "NSButtonCell"; title = "Ignore Case"; ObjectID = "GS5-w5-IIt"; */
+"GS5-w5-IIt.title" = "忽略大小寫";
+/* Class = "NSButtonCell"; title = "Respect language rules"; ObjectID = "x72-Sd-pMB"; */
+"x72-Sd-pMB.title" = "遵守語言規則";
+/* Class = "NSButtonCell"; title = "Treat numbers as numeric value"; ObjectID = "yXD-KA-8KI"; */
+"yXD-KA-8KI.title" = "將陣列視為數值";
+/* Class = "NSButtonCell"; title = "Keep the first line at the top"; ObjectID = "uUe-tD-Z8s"; */
+"uUe-tD-Z8s.title" = "首行置頂";
+/* Class = "NSButtonCell"; title = "In decending order"; ObjectID = "h1K-Og-3x3"; */
+"h1K-Og-3x3.title" = "降序";
+
+
+/* Class = "NSTextFieldCell"; title = "Delimiter:"; ObjectID = "CLj-6v-R1R"; */
+"CLj-6v-R1R.title" = "分界符：";
+/* Class = "NSTextFieldCell"; title = "Position:"; ObjectID = "HE1-PS-8J3"; */
+"HE1-PS-8J3.title" = "位置：";
+
+
+/* Class = "NSTextFieldCell"; title = "Pattern:"; ObjectID = "d12-uy-VE0"; */
+"d12-uy-VE0.title" = "模式：";
+/* Class = "NSTextFieldCell"; placeholderString = "Regular Expression"; ObjectID = "Ia7-Mb-FNn"; */
+"Ia7-Mb-FNn.placeholderString" = "正規表示式";
+/* Class = "NSButtonCell"; title = "Ignore case"; ObjectID = "Lr8-mD-svg"; */
+"Lr8-mD-svg.title" = "忽略大小寫";
+/* Class = "NSButtonCell"; title = "Use captured group:"; ObjectID = "eys-fy-HVq"; */
+"eys-fy-HVq.title" = "使用捕獲組：";
+
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "Lw7-xg-639"; */
+"Lw7-xg-639.title" = "取消";
+/* Class = "NSButtonCell"; title = "Sort"; ObjectID = "ara-FL-nKk"; */
+"ara-FL-nKk.title" = "排序";

--- a/CotEditor/zh-Hant.lproj/PreferencesWindow.strings
+++ b/CotEditor/zh-Hant.lproj/PreferencesWindow.strings
@@ -1,0 +1,45 @@
+//
+//  PreferencesWindow.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2020 1024jp
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSWindow"; title = "Preferences"; ObjectID = "KjF-xP-N55"; */
+"KjF-xP-N55.title" = "偏好設定";
+
+/* Class = "NSTabViewItem"; label = "General"; ObjectID = "CNJ-6L-fga"; */
+"CNJ-6L-fga.label" = "通用";
+/* Class = "NSTabViewItem"; label = "Window"; ObjectID = "5fL-58-BrZ"; */
+"5fL-58-BrZ.label" = "視窗";
+/* Class = "NSTabViewItem"; label = "Appearance"; ObjectID = "icK-P1-6ta"; */
+"icK-P1-6ta.label" = "外觀";
+/* Class = "NSTabViewItem"; label = "Edit"; ObjectID = "sh3-xI-elX"; */
+"sh3-xI-elX.label" = "編輯";
+/* Class = "NSTabViewItem"; label = "Format"; ObjectID = "frU-Pc-xZT"; */
+"frU-Pc-xZT.label" = "格式";
+/* Class = "NSTabViewItem"; label = "File Drop"; ObjectID = "aO6-oS-ZGt"; */
+"aO6-oS-ZGt.label" = "檔案拖拽";
+/* Class = "NSTabViewItem"; label = "Key Bindings"; ObjectID = "b8q-WN-1ls"; */
+"b8q-WN-1ls.label" = "按鍵繫結";
+/* Class = "NSTabViewItem"; label = "Print"; ObjectID = "UuB-iq-kOt"; */
+"UuB-iq-kOt.label" = "列印";

--- a/CotEditor/zh-Hant.lproj/PrintPane.strings
+++ b/CotEditor/zh-Hant.lproj/PrintPane.strings
@@ -1,0 +1,156 @@
+//
+//  PrintPane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Font:"; ObjectID = "C9y-bs-mE1"; */
+"C9y-bs-mE1.title" = "字型：";
+/* Class = "NSButtonCell"; title = "Same as document’s font"; ObjectID = "PfG-m4-gpq"; */
+"PfG-m4-gpq.title" = "與文件字型一致";
+/* Class = "NSButtonCell"; title = "Select…"; ObjectID = "3385"; */
+"3385.title" = "選擇…";
+
+/* Class = "NSTextFieldCell"; title = "Color:"; ObjectID = "3388"; */
+"3388.title" = "顏色：";
+/* Class = "NSMenuItem"; title = "Black and White"; ObjectID = "1353"; */
+"1353.title" = "黑白";
+/* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "1354"; */
+"1354.title" = "與文件設定一致";
+/* Class = "NSButtonCell"; title = "Print background"; ObjectID = "P53-bb-aGF"; */
+"P53-bb-aGF.title" = "列印背景";
+
+
+/* Class = "NSTextFieldCell"; title = "Line numbers:"; ObjectID = "3380"; */
+"3380.title" = "行號：";
+/* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "946"; */
+"946.title" = "不列印";
+/* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "947"; */
+"947.title" = "與文件設定一致";
+/* Class = "NSMenuItem"; title = "Print"; ObjectID = "948"; */
+"948.title" = "列印";
+
+/* Class = "NSTextFieldCell"; title = "Invisibles:"; ObjectID = "3382"; */
+"3382.title" = "不可見字元：";
+/* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "952"; */
+"952.title" = "不列印";
+/* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "953"; */
+"953.title" = "與文件設定一致";
+/* Class = "NSMenuItem"; title = "Print"; ObjectID = "954"; */
+"954.title" = "列印";
+
+
+
+/* Class = "NSButtonCell"; title = "Print header"; ObjectID = "3368"; */
+"3368.title" = "列印頁首";
+
+/* Class = "NSTextFieldCell"; title = "Primary:"; ObjectID = "3369"; */
+"3369.title" = "主：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "895"; */
+"895.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "uuc-7D-Iot"; */
+"uuc-7D-Iot.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "896"; */
+"896.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "897"; */
+"897.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "898"; */
+"898.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "893"; */
+"893.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; ObjectID = "90p-SJ-bXq"; */
+"90p-SJ-bXq.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"90p-SJ-bXq.ibShadowedToolTips[1]" = "居中";  /* Center */
+"90p-SJ-bXq.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */
+
+
+/* Class = "NSTextFieldCell"; title = "Secondary:"; ObjectID = "3373"; */
+"3373.title" = "次：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "906"; */
+"906.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "plk-U5-NGA"; */
+"plk-U5-NGA.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "902"; */
+"902.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "903"; */
+"903.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "904"; */
+"904.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "905"; */
+"905.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; ObjectID = "Jap-f3-ehL"; */
+"Jap-f3-ehL.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"Jap-f3-ehL.ibShadowedToolTips[1]" = "居中";  /* Center */
+"Jap-f3-ehL.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */
+
+
+
+/* Class = "NSButtonCell"; title = "Print footer"; ObjectID = "3375"; */
+"3375.title" = "列印頁尾";
+
+/* Class = "NSTextFieldCell"; title = "Primary:"; ObjectID = "3379"; */
+"3379.title" = "主：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "941"; */
+"941.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "Mvg-wT-FTM"; */
+"Mvg-wT-FTM.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "937"; */
+"937.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "938"; */
+"938.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "939"; */
+"939.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "940"; */
+"940.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; ObjectID = "Zgh-yF-xd2"; */
+"Zgh-yF-xd2.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"Zgh-yF-xd2.ibShadowedToolTips[1]" = "居中";  /* Center */
+"Zgh-yF-xd2.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */
+
+
+/* Class = "NSTextFieldCell"; title = "Primary:"; ObjectID = "3377"; */
+"3377.title" = "次：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "927"; */
+"927.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "ckJ-Cw-ccE"; */
+"ckJ-Cw-ccE.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "929"; */
+"929.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "930"; */
+"930.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "931"; */
+"931.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "932"; */
+"932.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; ObjectID = "Pjk-d8-E4v"; */
+"Pjk-d8-E4v.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"Pjk-d8-E4v.ibShadowedToolTips[1]" = "居中";  /* Center */
+"Pjk-d8-E4v.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */

--- a/CotEditor/zh-Hant.lproj/PrintPanelAccessory.strings
+++ b/CotEditor/zh-Hant.lproj/PrintPanelAccessory.strings
@@ -1,0 +1,149 @@
+//
+//  PrintPanelAccessory.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Color:"; ObjectID = "eXI-55-yQO"; */
+"eXI-55-yQO.title" = "顏色：";
+/* Class = "NSMenuItem"; title = "Black and White"; ObjectID = "590"; */
+"590.title" = "黑白";
+/* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "589"; */
+"589.title" = "與文件設定一致";
+/* Class = "NSButtonCell"; title = "Print background"; ObjectID = "Jff-bZ-Xbm"; */
+"Jff-bZ-Xbm.title" = "列印背景";
+
+/* Class = "NSTextFieldCell"; title = "Line Numbers:"; ObjectID = "716"; */
+"716.title" = "行號：";
+/* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "420"; */
+"420.title" = "不列印";
+/* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "419"; */
+"419.title" = "與文件設定一致";
+/* Class = "NSMenuItem"; title = "Print"; ObjectID = "418"; */
+"418.title" = "列印";
+
+/* Class = "NSTextFieldCell"; title = "Invisibles:"; ObjectID = "718"; */
+"718.title" = "不可見元素：";
+/* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "427"; */
+"427.title" = "與文件設定一致";
+/* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "428"; */
+"428.title" = "不列印";
+/* Class = "NSMenuItem"; title = "Print"; ObjectID = "426"; */
+"426.title" = "列印";
+
+
+
+/* Class = "NSButtonCell"; title = "Print header"; ObjectID = "708"; */
+"708.title" = "列印頁首";
+
+/* Class = "NSTextFieldCell"; title = "Primary:"; ObjectID = "706"; */
+"706.title" = "主：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "393"; */
+"393.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "UJ5-ki-qHL"; */
+"UJ5-ki-qHL.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "202"; */
+"202.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "203"; */
+"203.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "206"; */
+"206.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "200"; */
+"200.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; Aru-Gd-J0D.ibShadowedToolTips[0] = "Align Left"; ObjectID = "Aru-Gd-J0D"; */
+"Aru-Gd-J0D.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"Aru-Gd-J0D.ibShadowedToolTips[1]" = "居中";  /* Center */
+"Aru-Gd-J0D.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */
+
+
+
+/* Class = "NSTextFieldCell"; title = "Secondary:"; ObjectID = "707"; */
+"707.title" = "次：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "395"; */
+"395.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "6RR-gp-tKJ"; */
+"6RR-gp-tKJ.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "312"; */
+"312.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "307"; */
+"307.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "311"; */
+"311.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "310"; */
+"310.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; I4t-kQ-lvq.ibShadowedToolTips[0] = "Align Left"; ObjectID = "I4t-kQ-lvq"; */
+"I4t-kQ-lvq.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"I4t-kQ-lvq.ibShadowedToolTips[1]" = "居中";  /* Center */
+"I4t-kQ-lvq.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */
+
+
+
+/* Class = "NSButtonCell"; title = "Print footer"; ObjectID = "713"; */
+"713.title" = "列印頁尾";
+
+/* Class = "NSTextFieldCell"; title = "Primary:"; ObjectID = "711"; */
+"711.title" = "主：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "397"; */
+"397.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "Ro5-rK-S7p"; */
+"Ro5-rK-S7p.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "320"; */
+"320.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "315"; */
+"315.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "319"; */
+"319.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "318"; */
+"318.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; ObjectID = "njJ-Ab-dUQ"; */
+"njJ-Ab-dUQ.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"njJ-Ab-dUQ.ibShadowedToolTips[1]" = "居中";  /* Center */
+"njJ-Ab-dUQ.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */
+
+
+/* Class = "NSTextFieldCell"; title = "Secondary:"; ObjectID = "712"; */
+"712.title" = "次：";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "399"; */
+"399.title" = "無";
+/* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "i9p-3e-KNC"; */
+"i9p-3e-KNC.title" = "文法名";
+/* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "328"; */
+"328.title" = "檔案名稱";
+/* Class = "NSMenuItem"; title = "File Path"; ObjectID = "323"; */
+"323.title" = "檔案路徑";
+/* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "327"; */
+"327.title" = "列印日期";
+/* Class = "NSMenuItem"; title = "Page Number"; ObjectID = "326"; */
+"326.title" = "頁碼";
+
+/* Class = "NSSegmentedCell"; ObjectID = "xAm-2i-Sw1"; */
+"xAm-2i-Sw1.ibShadowedToolTips[0]" = "左對齊";  /* Align Left */
+"xAm-2i-Sw1.ibShadowedToolTips[1]" = "居中";  /* Center */
+"xAm-2i-Sw1.ibShadowedToolTips[2]" = "右對齊";  /* Align Right */

--- a/CotEditor/zh-Hant.lproj/ProgressView.strings
+++ b/CotEditor/zh-Hant.lproj/ProgressView.strings
@@ -1,0 +1,28 @@
+//
+//  ProgressView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "58"; */
+"58.title" = "取消";

--- a/CotEditor/zh-Hant.lproj/ReportTemplate.md
+++ b/CotEditor/zh-Hant.lproj/ReportTemplate.md
@@ -1,0 +1,25 @@
+
+按照示例進行填寫，並將它釋出到 [GitHub Issues](https://github.com/coteditor/CotEditor/issues) 上或是透過郵件傳送到 <coteditor.github@gmail.com>。請注意，透過郵件傳送的內容也會被共享至 Issue 頁面。請使用英文或者日文書寫報告內容。
+
+-----------------------------------------------
+
+## Environment (環境)
+
+- CotEditor: %SHORT_VERSION% (%BUNDLE_VERSION%)
+- System: macOS %SYSTEM_VERSION%
+- Language: Chinese (Simplified)
+
+
+## Short Description (簡單描述)
+
+<!-- 請在這裡輸入 -->
+
+
+## Steps to Reproduce the Issue (重現問題步驟)
+
+<!-- 請在這裡輸入 -->
+
+
+## Expected Result (期待結果)
+
+<!-- 請在這裡輸入 -->

--- a/CotEditor/zh-Hant.lproj/SaveDocumentAccessory.strings
+++ b/CotEditor/zh-Hant.lproj/SaveDocumentAccessory.strings
@@ -1,0 +1,28 @@
+//
+//  SaveDocumentAccessory.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2016-03-06.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2016 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSButtonCell"; title = "Give execute permission"; ObjectID = "KjO-BV-esE"; */
+"KjO-BV-esE.title" = "付與執行許可權";

--- a/CotEditor/zh-Hant.lproj/SyntaxCommentsEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxCommentsEditView.strings
@@ -1,0 +1,64 @@
+//
+//  SyntaxCommentsEditView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-14.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2015 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Inline comment:"; ObjectID = "b3O-ZW-iIp"; */
+"b3O-ZW-iIp.title" = "行註釋：";
+/* Class = "NSTextFieldCell"; title = "Begin with:"; ObjectID = "xWF-yX-yz5"; */
+"xWF-yX-yz5.title" = "以此開始：";
+/* Class = "NSTextFieldCell"; placeholderString = "Not defined"; ObjectID = "4qu-tU-wgL"; */
+"4qu-tU-wgL.placeholderString" = "未定義";
+
+/* Class = "NSTextFieldCell"; title = "Block comment:"; ObjectID = "bUT-iW-c0x"; */
+"bUT-iW-c0x.title" = "塊註釋：";
+/* Class = "NSTextFieldCell"; title = "Begin with:"; ObjectID = "508-hG-5PG"; */
+"508-hG-5PG.title" = "以此開始：";
+/* Class = "NSTextFieldCell"; placeholderString = "Not defined"; ObjectID = "TSS-rl-L2D"; */
+"TSS-rl-L2D.placeholderString" = "未定義";
+/* Class = "NSTextFieldCell"; title = "End with:"; ObjectID = "5bm-Fa-IZj"; */
+"5bm-Fa-IZj.title" = "以此結束：";
+/* Class = "NSTextFieldCell"; placeholderString = "Not defined"; ObjectID = "lMx-HP-1U1"; */
+"lMx-HP-1U1.placeholderString" = "未定義";
+
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not defined"; ObjectID = "Pcv-9r-6km"; */
+"Pcv-9r-6km.ibShadowedIsNilPlaceholder" = "未定義";
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not defined"; ObjectID = "a3u-7k-1dd"; */
+"a3u-7k-1dd.ibShadowedIsNilPlaceholder" = "未定義";
+/* Class = "IBBindingConnection"; ibShadowedIsNilPlaceholder = "Not defined"; ObjectID = "dwo-oN-tBR"; */
+"dwo-oN-tBR.ibShadowedIsNilPlaceholder" = "未定義";
+
+
+/* Class = "NSTableColumn"; headerCell.title = "Begin String"; ObjectID = "1an-HZ-pD7"; */
+"1an-HZ-pD7.headerCell.title" = "起始字串";
+/* Class = "NSTableColumn"; headerCell.title = "End String"; ObjectID = "XJa-sc-hM6"; */
+"XJa-sc-hM6.headerCell.title" = "結束字串";
+/* Class = "NSTableColumn"; ObjectID = "XJj-U2-0se"; */
+"XJj-U2-0se.headerCell.title" = "RE";  /* RE */
+"XJj-U2-0se.headerToolTip" = "正規表示式";  /* Regular Expression */
+/* Class = "NSTableColumn"; ObjectID = "oI5-31-pDw"; */
+"oI5-31-pDw.headerCell.title" = "IC";  /* IC */
+"oI5-31-pDw.headerToolTip" = "忽略大小寫";  /* Ignore Case (case-insensitive) */
+/* Class = "NSTableColumn"; headerCell.title = "Description"; ObjectID = "Bla-xg-t6E"; */
+"Bla-xg-t6E.headerCell.title" = "描述";

--- a/CotEditor/zh-Hant.lproj/SyntaxCompletionsEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxCompletionsEditView.strings
@@ -1,0 +1,31 @@
+//
+//  SyntaxCompletionsEditView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-14.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2015 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "If no word, the completion list will be generated from coloring settings."; ObjectID = "fJg-PK-TBB"; */
+"fJg-PK-TBB.title" = "如果沒有單詞，補全列表將由高亮設定生成。";
+
+/* Class = "NSTableColumn"; headerCell.title = "Completions"; ObjectID = "uGV-wD-V9T"; */
+"uGV-wD-V9T.headerCell.title" = "補全";

--- a/CotEditor/zh-Hant.lproj/SyntaxEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxEditView.strings
@@ -1,0 +1,37 @@
+//
+//  SyntaxEditView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Style Name:"; ObjectID = "987"; */
+"987.title" = "文法名：";
+/* Class = "NSTextFieldCell"; placeholderString = "Style Name"; ObjectID = "988"; */
+"988.placeholderString" = "文法名";
+
+/* Class = "NSButtonCell"; title = "Restore Defaults"; ObjectID = "1020"; */
+"1020.title" = "恢復預設";
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "986"; */
+"986.title" = "取消";
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "985"; */
+"985.title" = "好";

--- a/CotEditor/zh-Hant.lproj/SyntaxFileMappingEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxFileMappingEditView.strings
@@ -1,0 +1,49 @@
+//
+//  SyntaxFileMappingEditView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-14.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Extensions"; ObjectID = "6eS-Hj-xoA"; */
+"6eS-Hj-xoA.title" = "副檔名";
+/* Class = "NSTextFieldCell"; title = "(without dots)"; ObjectID = "QjK-XG-E4X"; */
+"QjK-XG-E4X.title" = "（不包括點）";
+
+/* Class = "NSTableColumn"; headerCell.title = "Extension"; ObjectID = "IIL-M3-S2o"; */
+"IIL-M3-S2o.headerCell.title" = "副檔名";
+
+
+/* Class = "NSTextFieldCell"; title = "Filenames"; ObjectID = "IAe-3F-qcV"; */
+"IAe-3F-qcV.title" = "檔名";
+
+/* Class = "NSTableColumn"; headerCell.title = "Filename"; ObjectID = "jwM-Gn-44e"; */
+"jwM-Gn-44e.headerCell.title" = "檔名";
+
+
+/* Class = "NSTextFieldCell"; title = "Interpreters"; ObjectID = "Axx-Oq-E9U"; */
+"Axx-Oq-E9U.title" = "直譯器";
+/* Class = "NSTextFieldCell"; title = "The interpreters are used to determine the syntax style from the shebang in the document."; ObjectID = "dIj-Z5-J2j"; */
+"dIj-Z5-J2j.title" = "直譯器將根據文件整體來決定文法高亮樣式。";
+
+/* Class = "NSTableColumn"; headerCell.title = "Interpreter"; ObjectID = "I6J-y5-MxO"; */
+"I6J-y5-MxO.headerCell.title" = "直譯器";

--- a/CotEditor/zh-Hant.lproj/SyntaxInfoEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxInfoEditView.strings
@@ -1,0 +1,41 @@
+//
+//  SyntaxInfoEditView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-14.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Version:"; ObjectID = "7gc-K7-WrS"; */
+"7gc-K7-WrS.title" = "版本：";
+/* Class = "NSTextFieldCell"; title = "Last modified:"; ObjectID = "wrI-z3-8T0"; */
+"wrI-z3-8T0.title" = "最後更新：";
+/* Class = "NSTextFieldCell"; title = "Distribution URL:"; ObjectID = "vOw-3n-nuT"; */
+"vOw-3n-nuT.title" = "釋出 URL：";
+/* Class = "NSTextFieldCell"; title = "Author:"; ObjectID = "aL3-Pf-XDB"; */
+"aL3-Pf-XDB.title" = "作者：";
+/* Class = "NSTextFieldCell"; title = "License:"; ObjectID = "qBg-TV-NzD"; */
+"qBg-TV-NzD.title" = "許可證：";
+/* Class = "NSTextFieldCell"; title = "Description:"; ObjectID = "4bM-8L-klg"; */
+"4bM-8L-klg.title" = "描述：";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Jump to URL"; ObjectID = "KlI-NS-4x6"; */
+"KlI-NS-4x6.ibShadowedToolTip" = "跳轉到URL";

--- a/CotEditor/zh-Hant.lproj/SyntaxMappingConflictsView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxMappingConflictsView.strings
@@ -1,0 +1,68 @@
+//
+//  SyntaxMappingConflictView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Syntax Style Mapping Conflicts"; ObjectID = "1022"; */
+"1022.title" = "文法樣式對映衝突";
+
+/* Class = "NSTextFieldCell"; title = "The following file mapping rules are registered in multiple styles. CotEditor uses the first style automatically. To resolve conflicts, edit each syntax style."; ObjectID = "gnp-H7-p1W"; */
+"gnp-H7-p1W.title" = "下列檔案對映規則被註冊了多種格式。CotEditor自動使用第一個格式。可以透過編輯每個文法格式來解決衝突。";
+
+
+/* Class = "NSTextFieldCell"; title = "Extension:"; ObjectID = "31z-NP-PkW"; */
+"31z-NP-PkW.title" = "副檔名：";
+
+/* Class = "NSTableColumn"; headerCell.title = "Extension"; ObjectID = "qkj-mf-TAf"; */
+"qkj-mf-TAf.headerCell.title" = "副檔名";
+/* Class = "NSTableColumn"; headerCell.title = "Used Style"; ObjectID = "oen-KK-QCa"; */
+"oen-KK-QCa.headerCell.title" = "已使用樣式";
+/* Class = "NSTableColumn"; headerCell.title = "Duplicated Styles"; ObjectID = "zSH-kc-yV3"; */
+"zSH-kc-yV3.headerCell.title" = "重複的樣式";
+
+
+/* Class = "NSTextFieldCell"; title = "Filename:"; ObjectID = "Msi-ee-MNF"; */
+"Msi-ee-MNF.title" = "檔名：";
+
+/* Class = "NSTableColumn"; headerCell.title = "Filename"; ObjectID = "YGO-sx-UT0"; */
+"YGO-sx-UT0.headerCell.title" = "檔名";
+/* Class = "NSTableColumn"; headerCell.title = "Used Style"; ObjectID = "cz8-8b-5qL"; */
+"cz8-8b-5qL.headerCell.title" = "已使用樣式";
+/* Class = "NSTableColumn"; headerCell.title = "Duplicated Styles"; ObjectID = "nge-9Z-A9D"; */
+"nge-9Z-A9D.headerCell.title" = "重複的樣式";
+
+
+/* Class = "NSTextFieldCell"; title = "Interpreter:"; ObjectID = "kam-EA-6Bv"; */
+"kam-EA-6Bv.title" = "直譯器：";
+
+/* Class = "NSTableColumn"; headerCell.title = "Interpreter"; ObjectID = "vBH-h4-kc0"; */
+"vBH-h4-kc0.headerCell.title" = "直譯器";
+/* Class = "NSTableColumn"; headerCell.title = "Used Style"; ObjectID = "DCi-HG-D1O"; */
+"DCi-HG-D1O.headerCell.title" = "已使用樣式";
+/* Class = "NSTableColumn"; headerCell.title = "Duplicated Styles"; ObjectID = "lyj-6e-zZV"; */
+"lyj-6e-zZV.headerCell.title" = "重複的樣式";
+
+
+/* Class = "NSButtonCell"; title = "Close"; ObjectID = "1021"; */
+"1021.title" = "關閉";

--- a/CotEditor/zh-Hant.lproj/SyntaxOutlineEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxOutlineEditView.strings
@@ -1,0 +1,50 @@
+//
+//  SyntaxOutlineEditView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-14.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Regular expressions to extract outline items"; ObjectID = "cBA-MO-VzQ"; */
+"cBA-MO-VzQ.title" = "用於提取大綱項的正規表示式";
+
+/* Class = "NSTableColumn"; headerCell.title = "Regular Expression String"; ObjectID = "vRg-cd-Ib2"; */
+"vRg-cd-Ib2.headerCell.title" = "正規表示式";
+
+/* Class = "NSTableColumn"; headerCell.title = "IC"; ObjectID = "1tC-mo-cEL"; */
+"1tC-mo-cEL.headerCell.title" = "IC";  /* IC */
+"1tC-mo-cEL.headerToolTip" = "忽略大小寫";  /* Ignore Case (case-insensitive) */
+
+/* Class = "NSTableColumn"; headerCell.title = "Description"; ObjectID = "6hB-wJ-niI"; */
+"6hB-wJ-niI.headerCell.title" = "描述";
+
+/* Class = "NSTextFieldCell"; title = "Title pattern"; ObjectID = "nnO-qN-dYF"; */
+"nnO-qN-dYF.title" = "標題樣式";
+/* Class = "NSTextFieldCell"; title = "(blank matches the whole string)"; ObjectID = "rqP-22-G2u"; */
+"rqP-22-G2u.title" = "（留空匹配整個字串）";
+
+/* Class = "NSButtonCell"; title = "Bold"; ObjectID = "iub-mE-wGf"; */
+"iub-mE-wGf.title" = "粗體";
+/* Class = "NSButtonCell"; title = "Italic"; ObjectID = "fUz-0u-0D4"; */
+"fUz-0u-0D4.title" = "斜體";
+/* Class = "NSButtonCell"; title = "Underline"; ObjectID = "00X-sB-42F"; */
+"00X-sB-42F.title" = "加下劃線";

--- a/CotEditor/zh-Hant.lproj/SyntaxTermsEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxTermsEditView.strings
@@ -1,0 +1,42 @@
+//
+//  SyntaxTermsEditView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-14.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2015 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTableColumn"; headerCell.title = "Begin String"; ObjectID = "QJ2-Qf-Fyb"; */
+"QJ2-Qf-Fyb.headerCell.title" = "起始字串";
+
+/* Class = "NSTableColumn"; headerCell.title = "End String"; ObjectID = "i4u-kF-59v"; */
+"i4u-kF-59v.headerCell.title" = "結束字串";
+
+/* Class = "NSTableColumn"; ObjectID = "hjj-zA-Yr9"; */
+"hjj-zA-Yr9.headerCell.title" = "RE";  /* RE */
+"hjj-zA-Yr9.headerToolTip" = "正規表示式";  /* Regular Expression */
+
+/* Class = "NSTableColumn"; ObjectID = "qJN-3P-dIu"; */
+"qJN-3P-dIu.headerCell.title" = "IC";  /* IC */
+"qJN-3P-dIu.headerToolTip" = "忽略大小寫";  /* Ignore Case (case-insensitive) */
+
+/* Class = "NSTableColumn"; headerCell.title = "Description"; ObjectID = "0ah-vG-2QL"; */
+"0ah-vG-2QL.headerCell.title" = "描述";

--- a/CotEditor/zh-Hant.lproj/UnicodeInputView.strings
+++ b/CotEditor/zh-Hant.lproj/UnicodeInputView.strings
@@ -1,0 +1,28 @@
+//
+//  UnicodeInputView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2020 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Invalid code"; ObjectID = "rz0-Df-N9T"; */
+"rz0-Df-N9T.ibShadowedIsNilPlaceholder" = "無效的程式碼";

--- a/CotEditor/zh-Hant.lproj/WarningsView.strings
+++ b/CotEditor/zh-Hant.lproj/WarningsView.strings
@@ -1,0 +1,45 @@
+//
+//  WarningsView.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-18.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Incompatible Characters"; ObjectID = "W1c-aP-XZa"; */
+"W1c-aP-XZa.title" = "不相容字元";
+
+/* Class = "NSTableColumn"; headerCell.title = "Converted"; ObjectID = "2AE-nU-rdc"; */
+"2AE-nU-rdc.headerCell.title" = "轉換後";
+/* Class = "NSTableColumn"; headerCell.title = "Character"; ObjectID = "Nhb-U5-BOF"; */
+"Nhb-U5-BOF.headerCell.title" = "字元";
+/* Class = "NSTableColumn"; headerCell.title = "Line"; ObjectID = "weY-lf-jGz"; */
+"weY-lf-jGz.headerCell.title" = "行";
+
+
+
+/* Class = "NSTextFieldCell"; title = "Inconsistent Line Endings"; ObjectID = "Yi4-Vk-FCZ"; */
+"Yi4-Vk-FCZ.title" = "換行符不一致";
+
+/* Class = "NSTableColumn"; headerCell.title = "Line"; ObjectID = "o1z-QY-xMY"; */
+"o1z-QY-xMY.headerCell.title" = "行";
+/* Class = "NSTableColumn"; headerCell.title = "Line Ending"; ObjectID = "Miu-uX-2tM"; */
+"Miu-uX-2tM.headerCell.title" = "換行";

--- a/CotEditor/zh-Hant.lproj/WindowPane.strings
+++ b/CotEditor/zh-Hant.lproj/WindowPane.strings
@@ -1,0 +1,99 @@
+//
+//  WindowPane.strings (Traditional Chinese)
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  Created by 1024jp on 2014-12-12.
+//  zh-Hant localization by Shiki Suen based on OnevCat's zh-Hans localization.
+//
+//  ------------------------------------------------------------------------------
+//
+//  © 2014-2022 CotEditor Project
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/* Class = "NSTextFieldCell"; title = "Prefer tabs:"; ObjectID = "8zu-3V-Obg"; */
+"8zu-3V-Obg.title" = "偏好標籤：";
+
+/* Class = "NSMenuItem"; title = "Respect System Setting"; ObjectID = "Guj-Kc-zf2"; */
+"Guj-Kc-zf2.title" = "使用系統設定";
+/* Class = "NSMenuItem"; title = "Never"; ObjectID = "o1f-vR-aFm"; */
+"o1f-vR-aFm.title" = "永不";  // The same as the popup menu selection in System Preferences > General
+/* Class = "NSMenuItem"; title = "Automatically"; ObjectID = "10Z-Xd-CLV"; */
+"10Z-Xd-CLV.title" = "自動";
+/* Class = "NSMenuItem"; title = "Always"; ObjectID = "OJs-2q-bg5"; */
+"OJs-2q-bg5.title" = "總是";  // The same as the popup menu selection in System Preferences > General
+
+
+/* Class = "NSTextFieldCell"; title = "Show:"; ObjectID = "iw9-Ba-eD2"; */
+"iw9-Ba-eD2.title" = "顯示：";
+/* Class = "NSButtonCell"; title = "Line numbers"; ObjectID = "A9U-Sx-or3"; */
+"A9U-Sx-or3.title" = "行號";
+/* Class = "NSButtonCell"; title = "Page guide at column:"; ObjectID = "3352"; */
+"3352.title" = "列位置頁面指示：";
+
+/* Class = "NSTextFieldCell"; title = "Writing Direction:"; ObjectID = "RwN-73-I8c"; */
+"RwN-73-I8c.title" = "書寫方向:";
+/* Class = "NSButtonCell"; title = "Left to right"; ObjectID = "3Kb-bF-CW0"; */
+"3Kb-bF-CW0.title" = "從左到右";
+/* Class = "NSButtonCell"; title = "Right to left"; ObjectID = "USo-8p-Edc"; */
+"USo-8p-Edc.title" = "從右到左";
+/* Class = "NSButtonCell"; title = "Vertical"; ObjectID = "Ge8-vU-lyg"; */
+"Ge8-vU-lyg.title" = "豎直";
+
+/* Class = "NSTextFieldCell"; title = "Overscroll:"; ObjectID = "7Nz-lv-JZb"; */
+"7Nz-lv-JZb.title" = "額外滾動：";
+
+
+/* Class = "NSTextFieldCell"; title = "Status bar shows:"; ObjectID = "kjP-FS-fyd"; */
+"kjP-FS-fyd.title" = "狀態列顯示：";
+/* Class = "NSButtonCell"; title = "Line count"; ObjectID = "6jK-xX-8AH"; */
+"6jK-xX-8AH.title" = "行數";
+/* Class = "NSButtonCell"; title = "Character count"; ObjectID = "sHZ-kO-Wvu"; */
+"sHZ-kO-Wvu.title" = "字元數";
+/* Class = "NSButtonCell"; title = "Word count"; ObjectID = "hRw-gK-ONt"; */
+"hRw-gK-ONt.title" = "字數";
+/* Class = "NSButtonCell"; title = "Location"; ObjectID = "ctl-Ps-V8Z"; */
+"ctl-Ps-V8Z.title" = "位置";
+/* Class = "NSButtonCell"; title = "Current line"; ObjectID = "JbR-gR-aiA"; */
+"JbR-gR-aiA.title" = "當前行";
+/* Class = "NSButtonCell"; title = "Column"; ObjectID = "SR0-Bx-Nh6"; */
+"SR0-Bx-Nh6.title" = "當前列";
+/* Class = "NSButtonCell"; title = "File size"; ObjectID = "ikB-dS-c4S"; */
+"ikB-dS-c4S.title" = "檔案尺寸";
+
+
+/* Class = "NSTextFieldCell"; title = "Window width:"; ObjectID = "JZ8-uq-7Kg"; */
+"JZ8-uq-7Kg.title" = "視窗寬度：";
+/* Class = "NSTextFieldCell"; title = "px"; ObjectID = "u8r-OW-Z1O"; */
+"u8r-OW-Z1O.title" = "px";
+/* Class = "NSTextFieldCell"; title = "height:"; ObjectID = "Zhk-Nt-kiD"; */
+"Zhk-Nt-kiD.title" = "高度：";
+/* Class = "NSTextFieldCell"; title = "px"; ObjectID = "VCx-PO-Fnr"; */
+"VCx-PO-Fnr.title" = "px";
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "Auto"; ObjectID = "hye-gP-iep"; */
+"hye-gP-iep.ibShadowedIsNilPlaceholder" = "自動";
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "Auto"; ObjectID = "UXj-fO-Vee"; */
+"UXj-fO-Vee.ibShadowedIsNilPlaceholder" = "自動";
+
+/* Class = "NSTextFieldCell"; title = "Split editor:"; ObjectID = "dug-hV-7hj"; */
+"dug-hV-7hj.title" = "分隔編輯器：";
+/* Class = "NSButtonCell"; title = "Horizontal"; ObjectID = "Bj6-2A-Nxj"; */
+"Bj6-2A-Nxj.title" = "水平";
+/* Class = "NSButtonCell"; title = "Vertical"; ObjectID = "sQC-O4-YON"; */
+"sQC-O4-YON.title" = "垂直";
+
+/* Class = "NSTextFieldCell"; title = "Editor opacity:"; ObjectID = "gSx-LA-TPc"; */
+"gSx-LA-TPc.title" = "編輯器透明度：";


### PR DESCRIPTION
To save some time, this PR is created **as a derivative work based on @onevcat 's zh-Hans localization**.

OpenCC is used for auto-conversion (zh-Hans to zh-Hant-TW).
However, I found that some words are not auto-converted correctly and fixed them manually.

At least, this PR is helpful to those people who born language is Traditional Chinese and can't understand Simplified Chinese glyphs. If further issues are found, we can use further PRs to fix them.

--------
このPRは OnevCat の簡体中国語翻訳に基づいてから作ったものである。
OpenCCで「zh-Hans」から「zh-Hant-TW」への自動転換をしましたが、転換し間違った単語は多少見つけたため直しました。
少なくとも、簡体中国語の簡体字を読みにくい人たちに甲斐のあるPRだと拙者の愚見です。
今後他の問題箇所を発見した場合、別のPRで直しましょう。