### PR TITLE
i18n@cp950 // Nomenclature fix to CotEditor 4.2.1.

### DIFF
--- a/CotEditor/zh-Hant.lproj/Acknowledgments.html
+++ b/CotEditor/zh-Hant.lproj/Acknowledgments.html
@@ -176,7 +176,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 <h3>Contributors on the original CotEditor (≦ 1.0)</h3>
 <ul>
     <li>本地化：<ul>
-        <li>英文 (文稿和幫助檔案)<br/>
+        <li>英文 (文件和幫助檔案)<br/>
             Y. Yamamoto</li>
     </ul></li>
     

--- a/CotEditor/zh-Hant.lproj/DocumentWindow.strings
+++ b/CotEditor/zh-Hant.lproj/DocumentWindow.strings
@@ -25,7 +25,7 @@
 //
 
 /* Class = "NSTabViewItem"; label = "Document Inspector"; ObjectID = "Kfj-q6-61N"; */
-"Kfj-q6-61N.label" = "文稿資訊";
+"Kfj-q6-61N.label" = "文件檢閱器";
 /* Class = "NSTabViewItem"; label = "Outline"; ObjectID = "hyM-2j-hen"; */
 "hyM-2j-hen.label" = "大綱";
 /* Class = "NSTabViewItem"; label = "Warnings"; ObjectID = "JZo-ok-Dks"; */

--- a/CotEditor/zh-Hant.lproj/EditPane.strings
+++ b/CotEditor/zh-Hant.lproj/EditPane.strings
@@ -25,7 +25,7 @@
 //
 
 /* Class = "NSTextFieldCell"; title = "Substitution:"; ObjectID = "SqI-BC-ar9"; */
-"SqI-BC-ar9.title" = "替換：";
+"SqI-BC-ar9.title" = "取代：";
 /* Class = "NSButtonCell"; title = "Smart copy/paste"; ObjectID = "3302"; */
 "3302.title" = "智慧複製/貼上";
 /* Class = "NSButtonCell"; title = "Automatically insert closing brackets and quotes"; ObjectID = "GRh-V2-hmW"; */
@@ -55,7 +55,7 @@
 /* Class = "NSTextFieldCell"; title = "spaces"; ObjectID = "as9-us-CuG"; */
 "as9-us-CuG.title" = "個空格縮排";
 /* Class = "NSButtonCell"; title = "Detect indent style on document opening"; ObjectID = "Cte-hW-0M3"; */
-"Cte-hW-0M3.title" = "在開啟檔案時檢測縮排格式";
+"Cte-hW-0M3.title" = "在開啟文件時檢測縮排格式";
 /* Class = "NSButtonCell"; title = "Indent selection with Tab key"; ObjectID = "aVn-PD-hen"; */
 "aVn-PD-hen.title" = "使用Tab鍵對選擇進行縮排";
 
@@ -84,11 +84,11 @@
 /* Class = "NSTextFieldCell"; title = "Completion list includes:"; ObjectID = "dLj-Kh-KtX"; */
 "dLj-Kh-KtX.title" = "補全列表包括：";
 /* Class = "NSButtonCell"; title = "Words in document"; ObjectID = "EJZ-N6-54G"; */
-"EJZ-N6-54G.title" = "檔案中的單詞";
+"EJZ-N6-54G.title" = "文件中的單字";
 /* Class = "NSButtonCell"; title = "Words defined in syntax style"; ObjectID = "1v9-7i-9RL"; */
-"1v9-7i-9RL.title" = "文法樣式中包含的單詞";
+"1v9-7i-9RL.title" = "文法樣式中包含的單字";
 /* Class = "NSButtonCell"; title = "Standard words"; ObjectID = "c5j-0N-f2R"; */
-"c5j-0N-f2R.title" = "標準單詞";
+"c5j-0N-f2R.title" = "標準單字";
 
 /* Class = "NSButtonCell"; title = "Suggest completions while typing"; ObjectID = "J1B-wA-rdr"; */
 "J1B-wA-rdr.title" = "忽略字串中的製表符和換行符";

--- a/CotEditor/zh-Hant.lproj/FindPanel.strings
+++ b/CotEditor/zh-Hant.lproj/FindPanel.strings
@@ -27,30 +27,30 @@
 // Find Panel
 
 /* Class = "NSPanel"; title = "Find & Replace"; ObjectID = "Wal-Sg-6d6"; */
-"Wal-Sg-6d6.title" = "查詢 & 替換";
+"Wal-Sg-6d6.title" = "檢索 & 取代";
 
 /* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Find"; ObjectID = "3sL-0v-4Cy"; */
-"3sL-0v-4Cy.ibShadowedIsNilPlaceholder" = "查詢";
+"3sL-0v-4Cy.ibShadowedIsNilPlaceholder" = "檢索";
 /* Class = "NSTextView"; ibShadowedToolTip = "Type the text to search for."; ObjectID = "hxw-DS-gxQ"; */
-"hxw-DS-gxQ.ibShadowedToolTip" = "輸入要查詢的文字。";
+"hxw-DS-gxQ.ibShadowedToolTip" = "輸入要檢索的文字。";
 /* Class = "NSTextView"; ibExternalAccessibilityDescription = "Find"; ObjectID = "hxw-DS-gxQ"; */
-"hxw-DS-gxQ.ibExternalAccessibilityDescription" = "查詢";
+"hxw-DS-gxQ.ibExternalAccessibilityDescription" = "檢索";
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Clear"; ObjectID = "ObJ-nS-x0g"; */
 "ObJ-nS-x0g.ibExternalAccessibilityDescription" = "清除";
 
 /* Class = "BindingConnection"; ibShadowedIsNilPlaceholder = "Replace"; ObjectID = "VUA-ld-ABD"; */
-"VUA-ld-ABD.ibShadowedIsNilPlaceholder" = "替換";
+"VUA-ld-ABD.ibShadowedIsNilPlaceholder" = "取代";
 /* Class = "NSTextView"; ibShadowedToolTip = "Type the text to replace the found text."; ObjectID = "qiQ-tb-XCa"; */
-"qiQ-tb-XCa.ibShadowedToolTip" = "輸入用來替換查詢到的文字。";
+"qiQ-tb-XCa.ibShadowedToolTip" = "輸入用來取代檢索到的文字。";
 /* Class = "NSTextView"; ibExternalAccessibilityDescription = "Replace"; ObjectID = "qiQ-tb-XCa"; */
-"qiQ-tb-XCa.ibExternalAccessibilityDescription" = "替換";
+"qiQ-tb-XCa.ibExternalAccessibilityDescription" = "取代";
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Clear"; ObjectID = "Y5M-CG-n0V"; */
 "Y5M-CG-n0V.ibExternalAccessibilityDescription" = "清除";
 
 /* Class = "NSButtonCell"; title = "Regular Expression"; ObjectID = "brT-HP-GVL"; */
 "brT-HP-GVL.title" = "正規表示式";
 /* Class = "NSButton"; ibShadowedToolTip = "Select to search with regular expression."; ObjectID = "8My-G5-daT"; */
-"8My-G5-daT.ibShadowedToolTip" = "選中以啟用正規表示式查詢。";
+"8My-G5-daT.ibShadowedToolTip" = "選中以啟用正規表示式檢索。";
 
 /* Class = "NSButtonCell"; title = "Ignore Case"; ObjectID = "4wg-Cz-ozb"; */
 "4wg-Cz-ozb.title" = "忽略大小寫";
@@ -60,7 +60,7 @@
 /* Class = "NSButtonCell"; title = "In Selection"; ObjectID = "9bc-9Q-fhd"; */
 "9bc-9Q-fhd.title" = "選中範圍內";
 /* Class = "NSButton"; ibShadowedToolTip = "Select to search text only from selection."; ObjectID = "tu7-IT-dA3"; */
-"tu7-IT-dA3.ibShadowedToolTip" = "選中僅在選擇範圍內進行文字查詢。";
+"tu7-IT-dA3.ibShadowedToolTip" = "選中僅在選擇範圍內進行文字檢索。";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Show quick reference for regular expression syntax."; ObjectID = "i2l-7Z-Zmf"; */
 "i2l-7Z-Zmf.ibShadowedToolTip" = "顯示正規表示式快速參考。";
@@ -69,49 +69,49 @@
 // Buttons
 
 /* Class = "NSButtonCell"; title = "Find All"; ObjectID = "XLZ-92-VVF"; */
-"XLZ-92-VVF.title" = "查詢全部";
+"XLZ-92-VVF.title" = "檢索全部";
 /* Class = "NSButton"; ibShadowedToolTip = "Find and list up all matches."; ObjectID = "OCv-Y5-8XR"; */
 "OCv-Y5-8XR.ibShadowedToolTip" = "列出所有匹配。";
 
 /* Class = "NSButtonCell"; title = "Replace All"; ObjectID = "5gU-5y-iLn"; */
-"5gU-5y-iLn.title" = "替換全部";
+"5gU-5y-iLn.title" = "取代全部";
 /* Class = "NSButton"; ibShadowedToolTip = "Replace all matches with the replacement text."; ObjectID = "RR6-rj-B8P"; */
-"RR6-rj-B8P.ibShadowedToolTip" = "將所有匹配用替換文字替換。";
+"RR6-rj-B8P.ibShadowedToolTip" = "將所有匹配用取代文字取代。";
 
 /* Class = "NSButtonCell"; title = "Replace"; ObjectID = "W4Z-S2-wvv"; */
-"W4Z-S2-wvv.title" = "替換";
+"W4Z-S2-wvv.title" = "取代";
 // Note: The tooltip for "Replace button is set the in FindPanelController.
 
 /* Class = "NSSegmentedCell"; ObjectID = "u6p-Hz-aK5"; */
-"u6p-Hz-aK5.ibShadowedToolTips[0]" = "查詢前一個匹配。";  /* "Find previous match." */
-"u6p-Hz-aK5.ibShadowedToolTips[1]" = "查詢後一個匹配。";  /* "Find next match." */
+"u6p-Hz-aK5.ibShadowedToolTips[0]" = "檢索前一個匹配。";  /* "Find previous match." */
+"u6p-Hz-aK5.ibShadowedToolTips[1]" = "檢索後一個匹配。";  /* "Find next match." */
 
 /* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Recent Searches"; ObjectID = "3ZH-bg-rl5"; */
-"3ZH-bg-rl5.ibExternalAccessibilityDescription" = "最近查詢";
+"3ZH-bg-rl5.ibExternalAccessibilityDescription" = "最近檢索";
 /* Class = "NSMenuItem"; title = "Recent Searches"; ObjectID = "cdV-rY-hCN"; */
-"cdV-rY-hCN.title" = "最近查詢";
+"cdV-rY-hCN.title" = "最近檢索";
 /* Class = "NSMenuItem"; title = "Clear Recent Searches"; ObjectID = "vE8-oK-xlC"; */
-"vE8-oK-xlC.title" = "清除最近查詢";
+"vE8-oK-xlC.title" = "清除最近檢索";
 
 /* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Recent Replacements"; ObjectID = "Hw7-zz-RG8"; */
-"Hw7-zz-RG8.ibExternalAccessibilityDescription" = "最近替換";
+"Hw7-zz-RG8.ibExternalAccessibilityDescription" = "最近取代";
 /* Class = "NSMenuItem"; title = "Recent Replacements"; ObjectID = "7cw-iQ-0LM"; */
-"7cw-iQ-0LM.title" = "最近替換";
+"7cw-iQ-0LM.title" = "最近取代";
 /* Class = "NSMenuItem"; title = "Clear Recent Replacements"; ObjectID = "vfK-an-Qnl"; */
-"vfK-an-Qnl.title" = "清除最近替換";
+"vfK-an-Qnl.title" = "清除最近取代";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Set advanced options"; ObjectID = "ESq-ws-6H3"; */
-"ESq-ws-6H3.ibShadowedToolTip" = "設定高階選項";
-"ESq-ws-6H3.ibExternalAccessibilityDescription" = "高階選項";
+"ESq-ws-6H3.ibShadowedToolTip" = "設定進階選項";
+"ESq-ws-6H3.ibExternalAccessibilityDescription" = "進階選項";
 
 
 // Find Result
 
 /* Class = "NSButton"; UeN.ibShadowedToolTip = "Close find result."; ObjectID = "oC1-bN-UeN"; */
-"oC1-bN-UeN.ibShadowedToolTip" = "關閉查詢結果。";
+"oC1-bN-UeN.ibShadowedToolTip" = "關閉檢索結果。";
 
 /* Class = "BindingConnection"; ibShadowedDisplayPattern = "Find String: %{value1}@"; ObjectID = "2MH-SD-x1y"; */
-"2MH-SD-x1y.ibShadowedDisplayPattern" = "查詢字串：%{value1}@";
+"2MH-SD-x1y.ibShadowedDisplayPattern" = "檢索字串：%{value1}@";
 
 /* Class = "NSTableColumn"; headerCell.title = "Line"; ObjectID = "CPd-0W-bKv"; */
 "CPd-0W-bKv.headerCell.title" = "行";

--- a/CotEditor/zh-Hant.lproj/FindPreferencesView.strings
+++ b/CotEditor/zh-Hant.lproj/FindPreferencesView.strings
@@ -25,13 +25,13 @@
 //
 
 /* Class = "NSTextFieldCell"; title = "Advanced Find Options"; ObjectID = "Dl6-kv-hhz"; */
-"Dl6-kv-hhz.title" = "高階查詢選項";
+"Dl6-kv-hhz.title" = "進階檢索選項";
 
 
 /* Class = "NSButtonCell"; title = "Wrap search around"; ObjectID = "o7S-uI-urg"; */
-"o7S-uI-urg.title" = "折行查詢";
+"o7S-uI-urg.title" = "折行檢索";
 /* Class = "NSButtonCell"; title = "Select next match after replace"; ObjectID = "XBp-LE-3Ry"; */
-"XBp-LE-3Ry.title" = "替換後選擇下一個匹配";
+"XBp-LE-3Ry.title" = "取代後選擇下一個匹配";
 /* Class = "NSButtonCell"; title = "Auto-close progress dialog"; ObjectID = "KBq-zH-H2M"; */
 "KBq-zH-H2M.title" = "自動關閉進度表";
 
@@ -39,33 +39,33 @@
 // Textual Search
 
 /* Class = "NSTextFieldCell"; title = "Textual Search"; ObjectID = "d1L-6X-N8c"; */
-"d1L-6X-N8c.title" = "文字查詢";
+"d1L-6X-N8c.title" = "文字檢索";
 
 /* Class = "NSButtonCell"; title = "Match only whole word"; ObjectID = "Na3-Ur-cf8"; */
 "Na3-Ur-cf8.title" = "僅全字匹配";
 /* Class = "NSButton"; ibShadowedToolTip = "Restrict search results to the whole words."; ObjectID = "eqE-mg-d9b"; */
-"eqE-mg-d9b.ibShadowedToolTip" = "將查詢結果限定於全字。";
+"eqE-mg-d9b.ibShadowedToolTip" = "將檢索結果限定於全字。";
 
 /* Class = "NSButtonCell"; title = "Distinguish characters strictly"; ObjectID = "mY4-am-wla"; */
 "mY4-am-wla.title" = "嚴格區分字元";
 /* Class = "NSButton"; ibShadowedToolTip = "Exact character-by-character equivalence."; ObjectID = "KG4-LQ-sen"; */
-"KG4-LQ-sen.ibShadowedToolTip" = "逐字元相等查詢";
+"KG4-LQ-sen.ibShadowedToolTip" = "逐字元相等檢索";
 
 /* Class = "NSButtonCell"; title = "Ignore diacritical marks"; ObjectID = "OUc-5d-N7I"; */
 "OUc-5d-N7I.title" = "忽略變音符號";
 /* Class = "NSButton"; ibShadowedToolTip = "Search Ignore diacritical marks (e.g., ö = o)."; ObjectID = "YYY-qb-T00"; */
-"YYY-qb-T00.ibShadowedToolTip" = "忽略變音符號進行查詢 (例如ö = o)。";
+"YYY-qb-T00.ibShadowedToolTip" = "忽略變音符號進行檢索 (例如ö = o)。";
 
 /* Class = "NSButtonCell"; title = "Ignores width differences"; ObjectID = "Jug-Dk-JMZ"; */
 "Jug-Dk-JMZ.title" = "忽略字元寬度";
 /* Class = "NSButton"; ibShadowedToolTip = "Search ignores width differences in character forms (e.g., ａ = a)."; ObjectID = "A5O-jt-o7T"; */
-"A5O-jt-o7T.ibShadowedToolTip" = "忽略字元形式的寬度進行查詢 (例如ａ = a)。";
+"A5O-jt-o7T.ibShadowedToolTip" = "忽略字元形式的寬度進行檢索 (例如ａ = a)。";
 
 
 // Regular Expression
 
 /* Class = "NSTextFieldCell"; title = "Regular Expression Search"; ObjectID = "Xa9-i4-ELR"; */
-"Xa9-i4-ELR.title" = "正規表示式查詢";
+"Xa9-i4-ELR.title" = "正規表示式檢索";
 
 /* Class = "NSButtonCell"; title = "Dot matches line separators"; ObjectID = "nqr-AM-oJQ"; */
 "nqr-AM-oJQ.title" = "使點匹配換行";
@@ -83,6 +83,6 @@
 "VMh-Tq-bq0.ibShadowedToolTip" = "使用Unicode TR#29指定字詞邊界";
 
 /* Class = "NSButtonCell"; title = "Unescape replacement string"; ObjectID = "rTR-zE-Wff"; */
-"rTR-zE-Wff.title" = "解碼替換字串";
+"rTR-zE-Wff.title" = "解碼取代字串";
 /* Class = "NSButton"; ibShadowedToolTip = "Unescape meta characters with backslash in replacement string."; ObjectID = "PLV-vr-cdI"; */
-"PLV-vr-cdI.ibShadowedToolTip" = "使用反斜槓元字元解碼替換字串";
+"PLV-vr-cdI.ibShadowedToolTip" = "使用反斜槓元字元解碼取代字串";

--- a/CotEditor/zh-Hant.lproj/FormatPane.strings
+++ b/CotEditor/zh-Hant.lproj/FormatPane.strings
@@ -42,7 +42,7 @@
 /* Class = "NSButtonCell"; title = "Edit List…"; ObjectID = "3275"; */
 "3275.title" = "編輯列表…";
 /* Class = "NSButtonCell"; title = "Refer to encoding declaration in document"; ObjectID = "3280"; */
-"3280.title" = "參考檔案中的編碼宣告";
+"3280.title" = "參考文件中的編碼宣告";
 
 
 
@@ -58,7 +58,7 @@
 "vlw-Tc-sLl.title" = "可用的文法樣式：";
 
 /* Class = "NSView"; ibShadowedToolTip = "This style is customized."; ObjectID = "cbJ-XK-bnG"; */
-"cbJ-XK-bnG.ibShadowedToolTip" = "該樣式已被自定義。";
+"cbJ-XK-bnG.ibShadowedToolTip" = "該樣式已被自訂。";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Remove selected style"; ObjectID = "dI1-Dk-Mce"; */
 "dI1-Dk-Mce.ibShadowedToolTip" = "移除選中的樣式";

--- a/CotEditor/zh-Hant.lproj/GeneralPane.strings
+++ b/CotEditor/zh-Hant.lproj/GeneralPane.strings
@@ -33,7 +33,7 @@
 "wmw-xg-bSt.title" = "當沒有可以開啟的檔案時：";
 
 /* Class = "NSMenuItem"; title = "Create New Document"; ObjectID = "i4c-DG-ADS"; */
-"i4c-DG-ADS.title" = "建立新檔案";
+"i4c-DG-ADS.title" = "建立新文件";
 /* Class = "NSMenuItem"; title = "Show Open Dialog"; ObjectID = "hIX-mh-cG4"; */
 "hIX-mh-cG4.title" = "顯示開啟對話方塊";
 /* Class = "NSMenuItem"; title = "Do Nothing"; ObjectID = "KgD-GV-alV"; */
@@ -41,7 +41,7 @@
 
 
 /* Class = "NSTextFieldCell"; title = "Document save:"; ObjectID = "Ki4-3Y-AZL"; */
-"Ki4-3Y-AZL.title" = "檔案儲存：";
+"Ki4-3Y-AZL.title" = "文件儲存：";
 
 /* Class = "NSButtonCell"; title = "Enable Auto Save with Versions"; ObjectID = "SGo-FL-Pax"; */
 "SGo-FL-Pax.title" = "開啟帶有版本的自動儲存";
@@ -50,7 +50,7 @@
 
 
 /* Class = "NSTextFieldCell"; title = "When document is changed by another application:"; ObjectID = "x4n-2n-I3p"; */
-"x4n-2n-I3p.title" = "當檔案被其他應用更改時：";
+"x4n-2n-I3p.title" = "當文件被其他應用更改時：";
 
 /* Class = "NSButtonCell"; title = "Keep CotEditor’s edition"; ObjectID = "sBH-MX-cTd"; */
 "sBH-MX-cTd.title" = "保留CotEditor的版本";
@@ -66,7 +66,7 @@
 /* Class = "NSButtonCell"; title = "Ignore line endings when counting characters"; ObjectID = "3306"; */
 "3306.title" = "字元計數時忽略行尾";
 /* Class = "NSButtonCell"; title = "Link URLs in document"; ObjectID = "tPy-Ox-YpP"; */
-"tPy-Ox-YpP.title" = "連結檔案中的URL";
+"tPy-Ox-YpP.title" = "連結文件中的URL";
 /* Class = "NSButtonCell"; title = "Check spelling while typing"; ObjectID = "3300"; */
 "3300.title" = "輸入時檢查拼寫";
 /* Class = "NSButtonCell"; title = "Highlight matching braces “()” “[]” “{}”"; ObjectID = "RrC-LL-hid"; */

--- a/CotEditor/zh-Hant.lproj/InfoPlist.strings
+++ b/CotEditor/zh-Hant.lproj/InfoPlist.strings
@@ -31,7 +31,7 @@
 "Text document" = "文字文件";
 "Plain text" = "純文字";
 "CotEditor Theme" = "CotEditor主題";
-"CotEditor Replacement Definition" = "CotEditor替換定義";
+"CotEditor Replacement Definition" = "CotEditor取代定義";
 "BibTeX bibliography" = "BibTeX參考書目";
 "Configuration" = "配置檔案";
 "C header" = "C頭檔案";

--- a/CotEditor/zh-Hant.lproj/Localizable.strings
+++ b/CotEditor/zh-Hant.lproj/Localizable.strings
@@ -40,7 +40,7 @@
 "incompatible characters" = "不兼容字元";
 "status bar" = "狀態欄";
 "editor" = "編輯器";
-"navigation bar" = "導航欄";
+"navigation bar" = "巡覽列";
 "line numbers" = "行號";
 "find result" = "查找結果";
 "Use print font" = "使用列印字體";
@@ -63,7 +63,7 @@
 "“%@” is a CotEditor theme file." = "「%@」是CotEditor主題檔案";
 "Do you want to install this theme?" = "是否安裝主題？";
 "Install" = "安裝";
-"Open as Text File" = "以文字方式打開";
+"Open as Text File" = "以文字方式開啟";
 "A new theme named “%@” has been successfully installed." = "新主題「%@」安裝完成";
 
 // Window title of issue report
@@ -72,15 +72,15 @@
 
 
 /* MARK: Text Finder */
-"Replace" = "替換";
+"Replace" = "取代";
 "Find All" = "查找全部";
-"Replace All" = "替換全部";
+"Replace All" = "取代全部";
 "Highlight" = "高亮";
 "Searching in text…" = "正在文字中搜索…";
 "%@ string found." = "找到%@個匹配";
 "%@ strings found." = "找到%@個匹配";
-"%@ string replaced." = "已替換%@個匹配";
-"%@ strings replaced." = "已替換%@個匹配";
+"%@ string replaced." = "已取代%@個匹配";
+"%@ strings replaced." = "已取代%@個匹配";
 "Invalid regular expression" = "無效的正規表達式";
 "Empty find string" = "空的搜索字元串";
 "The option “in selection” is enabled, although nothing is selected." = "「在選擇中搜索」選項被激活，但是並沒有內容被選中。";
@@ -93,12 +93,12 @@
 
 
 /* MARK: FindPanelController */
-"Replace the current selection with the replacement text, then find the next match." = "用替換文字替換當前選中內容，然後查找下一個匹配項目";
-"Replace the current selection with the replacement text." = "用替換文字替換當前選中內容";
+"Replace the current selection with the replacement text, then find the next match." = "用取代文字取代當前選中內容，然後查找下一個匹配項目";
+"Replace the current selection with the replacement text." = "用取代文字取代當前選中內容";
 "Not Found" = "未找到";
 "%i found" = "找到%i項";  // %i is number of founds
-"Not Replaced" = "沒有進行替換";
-"%i replaced" = "%i處被替換";  // %i is number of replaced
+"Not Replaced" = "沒有進行取代";
+"%i replaced" = "%i處被取代";  // %i is number of replaced
 
 
 
@@ -117,7 +117,7 @@
 "any character" = "任意字元";
 "new line character" = "換行符";
 "tab character" = "tab符號";
-"word character" = "單詞字元";
+"word character" = "單字字元";
 "whitespace character" = "空格字元";
 "non-whitespace character" = "非空格字元";
 "decimal number" = "數字";
@@ -127,7 +127,7 @@
 "Anchors" = "錨點";
 "beginning of the line" = "行首";
 "end of the line" = "行末";
-"word boundary" = "單詞邊界";
+"word boundary" = "單字邊界";
 
 "Quantifiers" = "數量";
 "1 or 0 times" = "1次或0次";
@@ -162,12 +162,12 @@
 
 // Binary file alert
 "The file “%@” doesn’t appear to be text data." = "檔案「%@」不是文字資料";
-"The file appears to be %@.\n\nDo you really want to open the file?" = "該檔案看起來是%@。\n\n確定要打開該檔案？";
+"The file appears to be %@.\n\nDo you really want to open the file?" = "該檔案看起來是%@。\n\n確定要開啟該檔案？";
 
 // Large file alert
 "The file “%@” has a size of %@." = "「%@」檔案尺寸為%@。";
-"Opening such a large file can make the application slow or unresponsive.\n\nDo you really want to open the file?" = "打開大型檔案可能導致應用速度變慢。\n\n確定要打開該檔案？";
-"Open" = "打開";
+"Opening such a large file can make the application slow or unresponsive.\n\nDo you really want to open the file?" = "開啟大型檔案可能導致應用速度變慢。\n\n確定要開啟該檔案？";
+"Open" = "開啟";
 
 
 
@@ -178,7 +178,7 @@
 
 // Convert or reinterpret encoding alert
 "File encoding" = "檔案編碼";
-"Do you want to convert or reinterpret this document using “%@”?" = "要使用「%@」進行轉換或者再次解釋嗎？";
+"Do you want to convert or reinterpret this document using “%@”?" = "要使用「%@」進行轉換或者再次解釋這份文件嗎？";
 "Convert" = "轉換";
 "Reinterpret" = "再次解釋";
 
@@ -190,11 +190,11 @@
 
 // Encoding change with unsaved changes alert
 "The document has unsaved changes." = "該文件中含有未儲存的修改。";
-"Do you want to discard the changes and reopen the document using “%@”?" = "你確認放棄更改，並使用「%@」重新打開文件嗎？";  // %@ is an encoding name.
+"Do you want to discard the changes and reopen the document using “%@”?" = "你確認放棄更改，並使用「%@」重新開啟該文件嗎？";  // %@ is an encoding name.
 "Discard Changes" = "放棄修改";
 
 // Reinterpretation failed alert
-"The document doesn’t have a file to reinterpret." = "該文件沒有用來再次解釋的檔案。";
+"The document doesn’t have a file to reinterpret." = "該文件沒有要用來再次解釋的檔案。";
 "The file “%@” couldn’t be reinterpreted using text encoding “%@”." = "檔案「%@」無法使用「%@」編碼再次解釋。";
 "The file may have been saved using a different text encoding, or it may not be a text file." = "該檔案可能已使用了不同的文字編碼來存儲，或者可能不是文字檔案。";
 
@@ -205,7 +205,7 @@
 
 // Inconsistent line ending alert
 "The document has inconsistent line endings." = "文件包含不一致的換行符。";
-"Do you want to convert all line endings to %@, the most common line endings in this document?" = "需要將所有換行符都替換為文件中最常使用的 %@ 嗎？";
+"Do you want to convert all line endings to %@, the most common line endings in this document?" = "需要將所有換行符都取代為文件中最常使用的 %@ 嗎？";
 "Don’t ask again for this document" = "對該文件不再詢問";
 "Convert" = "轉換";
 "Review" = "檢查";
@@ -272,7 +272,7 @@
 "Change tab width" = "更改Tab寬度";
 // menu
 "Tab Width" = "Tab寬度";
-"Custom…" = "自定義…";
+"Custom…" = "自訂…";
 
 "Wrap Lines" = "換行";
 // tooltip
@@ -299,19 +299,19 @@
 
 "Color Code" = "顏色代碼";
 // tooltip
-"Open Color Code Editor and set selection as color code" = "打開調色盤並將選中內容設為顏色代碼";
+"Open Color Code Editor and set selection as color code" = "開啟調色盤並將選中內容設為顏色代碼";
 
 "Emoji & Symbols" = "表情與符號";
 // tooltip
-"Show Emoji & Symbols palette" = "顯示查找和替換";
+"Show Emoji & Symbols palette" = "顯示查找和取代";
 
 "Find" = "查找";
 // tooltip
-"Show Find & Replace" = "顯示查找 & 替換";
+"Show Find & Replace" = "顯示查找 & 取代";
 
 "Print" = "列印";
 // tooltip
-"Print document" = "列印文稿";
+"Print document" = "列印文件";
 
 // tooltip
 // -> The toolbar label for "Share" is set automatically.
@@ -368,7 +368,7 @@
 "Black and White" = "黑白";
 "Print" = "列印";
 "Syntax Name" = "文法名";
-"Document Name" = "檔案名稱";
+"Document Name" = "文件名稱";
 "File Path" = "檔案路徑";
 "Print Date" = "列印日期";
 "Page Number" = "頁碼";
@@ -401,7 +401,7 @@
 
 /* MARK: EditorTextView */
 // Undo action names
-"Replace Text" = "替換文字";
+"Replace Text" = "取代文字";
 "Insert Text" = "插入文字";
 "Insert Snippet" = "插入片段";
 "Shift Right" = "右移";
@@ -442,8 +442,8 @@
 "Show Line Numbers" = "顯示行號";
 "Hide Status Bar" = "隱藏狀態欄";
 "Show Status Bar" = "顯示狀態欄";
-"Hide Navigation Bar" = "隱藏導航欄";
-"Show Navigation Bar" = "顯示導航欄";
+"Hide Navigation Bar" = "隱藏巡覽列";
+"Show Navigation Bar" = "顯示巡覽列";
 "Hide Invisibles" = "隱藏不可見元素";
 "Show Invisibles" = "顯示不可見元素";
 "Hide Page Guide" = "隱藏頁面指示";
@@ -620,13 +620,13 @@
 // Delete syntax style alert
 "Are you sure you want to delete “%@” syntax style?" = "確定刪除文法樣式「%@」？";
 "Delete" = "刪除";
-"Replace" = "替換";
+"Replace" = "取代";
 
 // Import syntax style file choose openPanel button
 "Import" = "導入";
 // Importing same name style alert
-"A new style named “%@” will be installed, but a custom style with the same name already exists." = "將要安裝名為「%@」的新樣式，但是已經存在同名的自定義樣式。";
-"Do you want to replace it?\nReplaced style can’t be restored." = "要替換樣式嗎？\n被替換的樣式無法將恢復。";
+"A new style named “%@” will be installed, but a custom style with the same name already exists." = "將要安裝名為「%@」的新樣式，但是已經存在同名的自訂樣式。";
+"Do you want to replace it?\nReplaced style can’t be restored." = "要取代樣式嗎？\n被取代的樣式無法將恢復。";
 
 // Export syntax style file savePanel label
 "Export As:" = "導出為：";
@@ -644,18 +644,18 @@
 /* MARK: ThemeManager */
 // Theme names
 "Untitled" = "未命名";
-"Customized Theme" = "自定義主題";
+"Customized Theme" = "自訂主題";
 
 // Theme import duplicated alert
-"A new theme named “%@” will be installed, but a custom theme with the same name already exists." = "將要安裝名為「%@」的新主題，但是已經存在同名的自定義主題。";
+"A new theme named “%@” will be installed, but a custom theme with the same name already exists." = "將要安裝名為「%@」的新主題，但是已經存在同名的自訂主題。";
 "Do you want to replace it?\nReplaced theme can’t be restored." = "要覆蓋原主題嗎？\n主題刪除後將無法還原。";
 
 
 
 /* MARK: ReplacementManager */
 // Replacements import duplicated alert
-"A new replacement definition named “%@” will be installed, but a definition with the same name already exists." = "名稱為「%@」的新替換定義將被安裝，但是已經存在相同名稱的定義。";
-"Do you want to replace it?\nReplaced definition can’t be restored." = "你想要替換該定義嗎？\n被替換的定義無法恢復。";
+"A new replacement definition named “%@” will be installed, but a definition with the same name already exists." = "名稱為「%@」的新取代定義將被安裝，但是已經存在相同名稱的定義。";
+"Do you want to replace it?\nReplaced definition can’t be restored." = "你想要取代該定義嗎？\n被取代的定義無法恢復。";
 
 
 
@@ -676,21 +676,21 @@
 
 /* MARK: ScriptManager */
 // Menu items
-"Open Scripts Folder" = "打開Scripts檔案夾";
+"Open Scripts Folder" = "開啟Scripts檔案夾";
 
 // Script menu item tooltips
-"Option-click to open script in editor." = "使用Option-單擊在編輯器中打開腳本。";
+"Option-click to open script in editor." = "使用Option-單擊在編輯器中開啟腳本。";
 
 
 
 /* MARK: Script */
 // No script target document errors
-"No document to get input." = "沒有輸入文件。";
-"No document to put output." = "沒有輸出文件。";
+"No document to get input." = "沒有要輸入的文件。";
+"No document to put output." = "沒有要輸出的文件。";
 
 // Script file error description
 "The script “%@” does not exist." = "腳本「%@」不存在。";
-"The script file “%@” couldn’t be opened." = "無法打開腳本檔案「%@」。";
+"The script file “%@” couldn’t be opened." = "無法開啟腳本檔案「%@」。";
 "The script “%@” can’t be executed because you don’t have the execute permission." = "由於沒有執行許可權，無法執行腳本「%@」。";
 "The script “%@” couldn’t be read." = "無法讀取腳本「%@」。";
 
@@ -703,7 +703,7 @@
 /* MARK: FileDropItem */
 // Descriptions about variables in the file drop feature
 "The dropped file absolute path." = "拖拽的檔案絕對路徑";
-"The relative path between the dropped file and the document." = "拖拽的檔案與編輯中文件的相對路徑";
+"The relative path between the dropped file and the document." = "拖拽的文件與編輯中檔案的相對路徑";
 "The dropped file’s name including extension (if exists)." = "拖拽的檔案的檔案名以及擴展名（如果存在）";
 "The dropped file’s name without extension." = "不帶擴展名的檔案名";
 "The dropped file’s extension." = "拖拽的檔案的擴展名";
@@ -732,7 +732,7 @@
 "Important change on CotEditor 4.2.0" = "CotEditor 4.2.0 重要變更";
 "From this version, CotEditor handles line endings more strictly." = "從該版本開始，CotEditor將會更嚴格地處理行尾。";
 "Due to this change, you may need manual migration for your settings below:" = "由於這個變更，你可能需要對下面的設定進行手動遷移：";
-"Multiple replacement definitions" = "多次替換的定義";
+"Multiple replacement definitions" = "多次取代的定義";
 "Syntax styles" = "文法風格";
 "CotEditor scripts" = "CotEditor腳本";
 "`\\n` for the regular expression matches only when the line ending is actually LF. Use `\\R` instead to match any kind of line ending." = "`\\n`僅在行尾確實是LF時進行匹配。如需匹配任意行尾，請使用`\\R`。";

--- a/CotEditor/zh-Hant.lproj/Main.strings
+++ b/CotEditor/zh-Hant.lproj/Main.strings
@@ -130,7 +130,7 @@
 /* Class = "NSMenuItem"; title = "Select Line"; ObjectID = "Cwp-ys-LJc"; */
 "Cwp-ys-LJc.title" = "選擇行";
 /* Class = "NSMenuItem"; title = "Select Word"; ObjectID = "0HX-j9-5jF"; */
-"0HX-j9-5jF.title" = "選擇單詞";
+"0HX-j9-5jF.title" = "選擇單字";
 
 /* Class = "NSMenuItem"; title = "Input Backslash"; ObjectID = "631"; */
 "631.title" = "輸入反斜槓";
@@ -146,7 +146,7 @@
 /* Class = "NSMenuItem"; title = "Show Spelling and Grammar"; ObjectID = "uXu-vF-RqZ"; */
 "uXu-vF-RqZ.title" = "顯示拼寫和文法";
 /* Class = "NSMenuItem"; title = "Check Document Now"; ObjectID = "hIk-Nu-0X3"; */
-"hIk-Nu-0X3.title" = "立即檢查文稿";
+"hIk-Nu-0X3.title" = "立即檢查文件";
 /* Class = "NSMenuItem"; title = "Check Spelling While Typing"; ObjectID = "9ny-sN-pmO"; */
 "9ny-sN-pmO.title" = "輸入時檢查拼寫";
 /* Class = "NSMenuItem"; title = "Check Grammar With Spelling"; ObjectID = "5eg-wx-S4p"; */
@@ -155,19 +155,19 @@
 "kQ8-FM-Cgx.title" = "自動糾正拼寫";
 
 /* Class = "NSMenu"; title = "Substitutions"; ObjectID = "2wy-A5-6kZ"; */
-"2wy-A5-6kZ.title" = "替換";
+"2wy-A5-6kZ.title" = "取代";
 /* Class = "NSMenuItem"; title = "Substitutions"; ObjectID = "yN3-iT-4Lq"; */
-"yN3-iT-4Lq.title" = "替換";
+"yN3-iT-4Lq.title" = "取代";
 /* Class = "NSMenuItem"; title = "Replace Quotes"; ObjectID = "7NX-1r-Wq7"; */
-"7NX-1r-Wq7.title" = "替換引號";
+"7NX-1r-Wq7.title" = "取代引號";
 /* Class = "NSMenuItem"; title = "Straighten Quotes"; ObjectID = "9gl-1h-Yit"; */
 "9gl-1h-Yit.title" = "直引號";
 /* Class = "NSMenuItem"; title = "Replace Dashes"; ObjectID = "hMS-qd-BCS"; */
-"hMS-qd-BCS.title" = "替換破折號";
+"hMS-qd-BCS.title" = "取代破折號";
 /* Class = "NSMenuItem"; title = "Replace Text"; ObjectID = "ue7-85-H8l"; */
-"ue7-85-H8l.title" = "替換文字";
+"ue7-85-H8l.title" = "取代文字";
 /* Class = "NSMenuItem"; title = "Show Substitutions"; ObjectID = "gqI-2M-XIx"; */
-"gqI-2M-XIx.title" = "顯示替換";
+"gqI-2M-XIx.title" = "顯示取代";
 /* Class = "NSMenuItem"; title = "Smart Copy/Paste"; ObjectID = "QKD-ue-EQp"; */
 "QKD-ue-EQp.title" = "智慧複製/貼上";
 /* Class = "NSMenuItem"; title = "Smart Quotes"; ObjectID = "sza-9T-f4h"; */
@@ -175,7 +175,7 @@
 /* Class = "NSMenuItem"; title = "Smart Dashes"; ObjectID = "cIp-rb-QPk"; */
 "cIp-rb-QPk.title" = "智慧破折號";
 /* Class = "NSMenuItem"; title = "Text Replacement"; ObjectID = "PSn-PG-o9k"; */
-"PSn-PG-o9k.title" = "文字替換";
+"PSn-PG-o9k.title" = "文字取代";
 
 /* Class = "NSMenuItem"; title = "Speech"; ObjectID = "gBe-fO-wVv"; */
 "gBe-fO-wVv.title" = "語音";
@@ -255,7 +255,7 @@
 /* Class = "NSMenuItem"; title = "8"; ObjectID = "9e0-Q5-Oqh"; */
 "9e0-Q5-Oqh.title" = "8";
 /* Class = "NSMenuItem"; title = "Custom…"; ObjectID = "gMO-5n-fiJ"; */
-"gMO-5n-fiJ.title" = "自定義…";
+"gMO-5n-fiJ.title" = "自訂…";
 /* Class = "NSMenuItem"; title = "Auto-Expand Tabs"; ObjectID = "hsG-8k-OKX"; */
 "hsG-8k-OKX.title" = "Tab轉為空格";
 
@@ -301,9 +301,9 @@
 "324.title" = "顯示";
 
 /* Class = "NSMenuItem"; title = "Hide Toolbar"; ObjectID = "612"; */
-"612.title" = "隱藏工具欄";
+"612.title" = "隱藏工具列";
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "613"; */
-"613.title" = "自定工具欄…";
+"613.title" = "自訂工具列…";
 
 
 /* Class = "NSMenuItem"; title = "Inspector"; ObjectID = "sYa-2o-iPk"; */
@@ -311,7 +311,7 @@
 /* Class = "NSMenu"; title = "Inspector"; ObjectID = "10j-rd-fWr"; */
 "10j-rd-fWr.title" = "檢查器";
 /* Class = "NSMenuItem"; title = "Document Inspector"; ObjectID = "564"; */
-"564.title" = "文稿資訊";
+"564.title" = "文件資訊";
 /* Class = "NSMenuItem"; title = "Outline"; ObjectID = "Gch-XD-tRl"; */
 "Gch-XD-tRl.title" = "大綱";
 /* Class = "NSMenuItem"; title = "Warnings"; ObjectID = "679"; */
@@ -320,7 +320,7 @@
 "I2p-KB-gxR.title" = "顯示檢查器";
 
 /* Class = "NSMenuItem"; title = "Show Navigation Bar"; ObjectID = "681"; */
-"681.title" = "顯示導航欄";
+"681.title" = "顯示巡覽列";
 /* Class = "NSMenuItem"; title = "Show Line Numbers"; ObjectID = "323"; */
 "323.title" = "顯示行號";
 /* Class = "NSMenuItem"; title = "Show Status Bar"; ObjectID = "325"; */
@@ -414,7 +414,7 @@
 /* Class = "NSMenuItem"; title = "Brackets"; ObjectID = "cTU-2P-7Tp"; */
 "cTU-2P-7Tp.title" = "方括弧";  // []
 /* Class = "NSMenuItem"; title = "Custom…"; ObjectID = "3VX-DL-PgT"; */
-"3VX-DL-PgT.title" = "自定義…";
+"3VX-DL-PgT.title" = "自訂…";
 
 /* Class = "NSMenuItem"; title = "Trim Trailing Whitespace"; ObjectID = "hBJ-Ge-278"; */
 "hBJ-Ge-278.title" = "移除行尾空白";
@@ -439,13 +439,13 @@
 "x1F-KX-2de.title" = "轉為大駝峰式";
 
 /* Class = "NSMenuItem"; title = "Half-width to Full-width"; ObjectID = "dVK-1s-xJq"; */
-"dVK-1s-xJq.title" = "半寬到全寬";
+"dVK-1s-xJq.title" = "半形到全形";
 /* Class = "NSMenuItem"; title = "Full-width to Half-width"; ObjectID = "Skr-vI-7VN"; */
-"Skr-vI-7VN.title" = "全寬到半寬";
+"Skr-vI-7VN.title" = "全形到半形";
 /* Class = "NSMenuItem"; title = "ASCII to Full-width ASCII"; ObjectID = "586"; */
-"586.title" = "ASCII到全寬ASCII";
+"586.title" = "ASCII到全形ASCII";
 /* Class = "NSMenuItem"; title = "Full-width ASCII to ASCII"; ObjectID = "588"; */
-"588.title" = "全寬ASCII到ASCII";
+"588.title" = "全形ASCII到ASCII";
 
 /* Class = "NSMenuItem"; title = "Japanese Text"; ObjectID = "XWV-by-mnw"; */
 "XWV-by-mnw.title" = "日文文字";
@@ -489,9 +489,9 @@
 "n6C-Km-BM9.ibShadowedToolTip" = "非官方的基於NFD的標準化形式與修改後的NFD對應";
 
 /* Class = "NSMenuItem"; title = "Insert Encoding Name"; ObjectID = "663"; */
-"663.title" = "插入編碼名字";
+"663.title" = "插入編碼名稱";
 /* Class = "NSMenuItem"; title = "Insert encoding name as IANA charset"; ObjectID = "663"; */
-"663.ibShadowedToolTip" = "插入作為IANA字符集的編碼名字";
+"663.ibShadowedToolTip" = "插入作為IANA字符集的編碼名稱";
 
 /* Class = "NSMenuItem"; title = "Inspect Character"; ObjectID = "ToR-yH-ahH"; */
 "ToR-yH-ahH.title" = "檢視文字";
@@ -503,38 +503,38 @@
 // MARK: Find
 
 /* Class = "NSMenuItem"; title = "Find"; ObjectID = "538"; */
-"538.title" = "查詢";
+"538.title" = "檢索";
 /* Class = "NSMenu"; title = "Find"; ObjectID = "kGA-vM-cdL"; */
-"kGA-vM-cdL.title" = "查詢";
+"kGA-vM-cdL.title" = "檢索";
 
 /* Class = "NSMenuItem"; title = "Find…"; ObjectID = "eP6-ss-sUG"; */
-"eP6-ss-sUG.title" = "查詢…";
+"eP6-ss-sUG.title" = "檢索…";
 /* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "NwE-Cf-L9F"; */
-"NwE-Cf-L9F.title" = "查詢下一個";
+"NwE-Cf-L9F.title" = "檢索下一個";
 /* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "wiV-Hh-7xU"; */
-"wiV-Hh-7xU.title" = "查詢上一個";
+"wiV-Hh-7xU.title" = "檢索上一個";
 /* Class = "NSMenuItem"; title = "Find Selected Text"; ObjectID = "l33-Nz-UAw"; */
-"l33-Nz-UAw.title" = "在選擇文字中查詢";
+"l33-Nz-UAw.title" = "在選擇文字中檢索";
 /* Class = "NSMenuItem"; title = "Find All"; ObjectID = "HgR-ke-6gq"; */
-"HgR-ke-6gq.title" = "查詢全部";
+"HgR-ke-6gq.title" = "檢索全部";
 /* Class = "NSMenuItem"; title = "Select All Find Matches"; ObjectID = "ULf-cT-Xvb"; */
-"ULf-cT-Xvb.title" = "選擇全部查詢到的匹配";
+"ULf-cT-Xvb.title" = "選擇全部檢索到的匹配";
 
 /* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "hTx-ef-3T2"; */
-"hTx-ef-3T2.title" = "查詢所選內容";
+"hTx-ef-3T2.title" = "檢索所選內容";
 /* Class = "NSMenuItem"; title = "Use Selection for Replace"; ObjectID = "kwa-lu-0Fz"; */
-"kwa-lu-0Fz.title" = "替換所選內容";
+"kwa-lu-0Fz.title" = "取代所選內容";
 /* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "p4A-mE-Ve3"; */
 "p4A-mE-Ve3.title" = "跳到所選內容";
 
 /* Class = "NSMenuItem"; title = "Replace"; ObjectID = "bnD-BP-sPi"; */
-"bnD-BP-sPi.title" = "替換";
+"bnD-BP-sPi.title" = "取代";
 /* Class = "NSMenuItem"; title = "Replace and Find Next"; ObjectID = "KrV-3z-r5B"; */
-"KrV-3z-r5B.title" = "替換並查詢下一個";
+"KrV-3z-r5B.title" = "取代並檢索下一個";
 /* Class = "NSMenuItem"; title = "Replace All"; ObjectID = "5HV-xo-NTK"; */
-"5HV-xo-NTK.title" = "替換全部";
+"5HV-xo-NTK.title" = "取代全部";
 /* Class = "NSMenuItem"; title = "Multiple Replace…"; ObjectID = "o7K-sI-KJA"; */
-"o7K-sI-KJA.title" = "多重替換…";
+"o7K-sI-KJA.title" = "多重取代…";
 
 /* Class = "NSMenuItem"; title = "Highlight"; ObjectID = "JAO-3o-fRo"; */
 "JAO-3o-fRo.title" = "高亮";

--- a/CotEditor/zh-Hant.lproj/MultipleReplacementPanel.strings
+++ b/CotEditor/zh-Hant.lproj/MultipleReplacementPanel.strings
@@ -25,7 +25,7 @@
 //
 
 /* Class = "NSWindow"; title = "Multiple Replace"; ObjectID = "rFC-87-Fxd"; */
-"rFC-87-Fxd.title" = "多重替換";
+"rFC-87-Fxd.title" = "多重取代";
 
 
 
@@ -64,19 +64,19 @@
 // MARK: Editor View
 
 /* Class = "NSTextFieldCell"; title = "Perform replacement using these rules in succession from the top down:"; ObjectID = "5Ey-vx-5Sm"; */
-"5Ey-vx-5Sm.title" = "使用這些規則從上至下連續進行替換:";
+"5Ey-vx-5Sm.title" = "使用這些規則從上至下連續進行取代:";
 
 
 /* Class = "NSTableColumn"; headerToolTip = "Enable"; ObjectID = "KTe-1r-oHM"; */
 "KTe-1r-oHM.headerToolTip" = "啟用";
 /* Class = "NSButton"; ibShadowedToolTip = "Select to enable this replacement rule."; ObjectID = "PuQ-No-wC1"; */
-"PuQ-No-wC1.ibShadowedToolTip" = "選擇以啟用該替換規則。";
+"PuQ-No-wC1.ibShadowedToolTip" = "選擇以啟用該取代規則。";
 
 /* Class = "NSTableColumn"; headerCell.title = "Find"; ObjectID = "zee-UW-TVR"; */
-"zee-UW-TVR.headerCell.title" = "查詢";
+"zee-UW-TVR.headerCell.title" = "檢索";
 
 /* Class = "NSTableColumn"; headerCell.title = "Replace With"; ObjectID = "nRC-aM-NZ2"; */
-"nRC-aM-NZ2.headerCell.title" = "替換";
+"nRC-aM-NZ2.headerCell.title" = "取代";
 
 /* Class = "NSTableColumn"; headerCell.title = "RE"; ObjectID = "VtR-Qz-MBf"; */
 "VtR-Qz-MBf.headerCell.title" = "RE";
@@ -92,7 +92,7 @@
 "Rhy-iE-CIC.headerCell.title" = "描述";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Select to search with regular expression."; ObjectID = "Lk4-Ym-IrV"; */
-"Lk4-Ym-IrV.ibShadowedToolTip" = "選中以啟用正規表示式查詢。";
+"Lk4-Ym-IrV.ibShadowedToolTip" = "選中以啟用正規表示式檢索。";
 /* Class = "NSButton"; ibShadowedToolTip = "Select to ignore character case on search."; ObjectID = "I23-3I-yq5"; */
 "I23-3I-yq5.ibShadowedToolTip" = "選中以忽略大小寫。";
 
@@ -101,58 +101,58 @@
 "gRf-KM-GZo.title" = "無效的規則將被跳過。";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Set advanced options"; ObjectID = "i8z-Xa-PxI"; */
-"i8z-Xa-PxI.ibShadowedToolTip" = "設定高階選項";
-"i8z-Xa-PxI.ibExternalAccessibilityDescription" = "高階選項";
+"i8z-Xa-PxI.ibShadowedToolTip" = "設定進階選項";
+"i8z-Xa-PxI.ibExternalAccessibilityDescription" = "進階選項";
 
 
 /* Class = "NSButtonCell"; title = "In Selection"; ObjectID = "4lm-Fu-Fcf"; */
 "4lm-Fu-Fcf.title" = "選中範圍內";
 /* Class = "NSButton"; ibShadowedToolTip = "Select to replace text only in selection."; ObjectID = "pfM-xk-MrN"; */
-"pfM-xk-MrN.ibShadowedToolTip" = "選中僅在選擇範圍內進行文字查詢。";
+"pfM-xk-MrN.ibShadowedToolTip" = "選中僅在選擇範圍內進行文字檢索。";
 
 /* Class = "NSButtonCell"; title = "Highlight"; ObjectID = "kdu-Ni-M64"; */
 "kdu-Ni-M64.title" = "高亮";
 /* Class = "NSButton"; ibShadowedToolTip = "Highlight all matches of the replacement rules."; ObjectID = "99C-Bz-ySi"; */
-"99C-Bz-ySi.ibShadowedToolTip" = "高亮所有匹配替換規則的文字。";
+"99C-Bz-ySi.ibShadowedToolTip" = "高亮所有匹配取代規則的文字。";
 
 /* Class = "NSButtonCell"; title = "Replace All"; ObjectID = "LI2-Hh-D6g"; */
-"LI2-Hh-D6g.title" = "替換全部";
+"LI2-Hh-D6g.title" = "取代全部";
 /* Class = "NSButton"; ibShadowedToolTip = "Replace all matches according to the replacement rules."; ObjectID = "Nth-za-4Ad"; */
-"Nth-za-4Ad.ibShadowedToolTip" = "依據替換規則替換所有匹配文字。";
+"Nth-za-4Ad.ibShadowedToolTip" = "依據取代規則取代所有匹配文字。";
 
 
 
 // MARK: Advanced Find Options
 
 /* Class = "NSTextFieldCell"; title = "Advanced Find Options"; ObjectID = "NTu-fa-URI"; */
-"NTu-fa-URI.title" = "高階查詢選項";
+"NTu-fa-URI.title" = "進階檢索選項";
 
 /* Class = "NSTextFieldCell"; title = "Textual Search"; ObjectID = "GU2-Em-4lt"; */
-"GU2-Em-4lt.title" = "文字查詢";
+"GU2-Em-4lt.title" = "文字檢索";
 
 /* Class = "NSButtonCell"; title = "Match only whole word"; ObjectID = "u12-3x-Oy6"; */
 "u12-3x-Oy6.title" = "僅全字匹配";
 /* Class = "NSButton"; ibShadowedToolTip = "Restrict search results to the whole words."; ObjectID = "lEO-tC-9zj"; */
-"lEO-tC-9zj.ibShadowedToolTip" = "將查詢結果限定於全字。";
+"lEO-tC-9zj.ibShadowedToolTip" = "將檢索結果限定於全字。";
 
 /* Class = "NSButtonCell"; title = "Distinguish characters strictly"; ObjectID = "tv3-0Q-m6B"; */
 "tv3-0Q-m6B.title" = "嚴格區分字元";
 /* Class = "NSButton"; ibShadowedToolTip = "Exact character-by-character equivalence."; ObjectID = "JiF-TN-azJ"; */
-"JiF-TN-azJ.ibShadowedToolTip" = "逐字元相等查詢";
+"JiF-TN-azJ.ibShadowedToolTip" = "逐字元相等檢索";
 
 /* Class = "NSButtonCell"; title = "Ignore diacritical marks"; ObjectID = "WWu-mC-MCz"; */
 "WWu-mC-MCz.title" = "忽略變音符號";
 /* Class = "NSButton"; ibShadowedToolTip = "Search ignores diacritical marks (ex. ö = o)."; ObjectID = "9pO-Jw-K7x"; */
-"9pO-Jw-K7x.ibShadowedToolTip" = "忽略變音符號進行查詢 (例如ö = o)。";
+"9pO-Jw-K7x.ibShadowedToolTip" = "忽略變音符號進行檢索 (例如ö = o)。";
 
 /* Class = "NSButtonCell"; title = "Ignore width differences"; ObjectID = "lVk-We-BSj"; */
 "lVk-We-BSj.title" = "忽略字元寬度";
 /* Class = "NSButton"; ibShadowedToolTip = "Search ignores width differences in character forms (ex. ａ = a)."; ObjectID = "6W5-EH-kOg"; */
-"6W5-EH-kOg.ibShadowedToolTip" = "忽略字元形式的寬度進行查詢 (例如ａ = a)。";
+"6W5-EH-kOg.ibShadowedToolTip" = "忽略字元形式的寬度進行檢索 (例如ａ = a)。";
 
 
 /* Class = "NSTextFieldCell"; title = "Regular Expression Search"; ObjectID = "eCk-TH-lBA"; */
-"eCk-TH-lBA.title" = "正規表示式查詢";
+"eCk-TH-lBA.title" = "正規表示式檢索";
 
 /* Class = "NSButtonCell"; title = "Dot matches line separators"; ObjectID = "ECw-cb-2hw"; */
 "ECw-cb-2hw.title" = "使點匹配換行";
@@ -170,6 +170,6 @@
 "6HK-St-iDw.ibShadowedToolTip" = "使用Unicode TR#29指定字詞邊界";
 
 /* Class = "NSButtonCell"; title = "Unescape replacement string"; ObjectID = "1sB-Qy-Kw8"; */
-"1sB-Qy-Kw8.title" = "解碼替換字串";
+"1sB-Qy-Kw8.title" = "解碼取代字串";
 /* Class = "NSButton"; ibShadowedToolTip = "Unescape meta characters with backslash in replacement string."; ObjectID = "QRo-Az-lq4"; */
-"QRo-Az-lq4.ibShadowedToolTip" = "使用反斜槓元字元解碼替換字串";
+"QRo-Az-lq4.ibShadowedToolTip" = "使用反斜槓元字元解碼取代字串";

--- a/CotEditor/zh-Hant.lproj/PrintPane.strings
+++ b/CotEditor/zh-Hant.lproj/PrintPane.strings
@@ -27,7 +27,7 @@
 /* Class = "NSTextFieldCell"; title = "Font:"; ObjectID = "C9y-bs-mE1"; */
 "C9y-bs-mE1.title" = "字型：";
 /* Class = "NSButtonCell"; title = "Same as document’s font"; ObjectID = "PfG-m4-gpq"; */
-"PfG-m4-gpq.title" = "與檔案字型一致";
+"PfG-m4-gpq.title" = "與文件字型一致";
 /* Class = "NSButtonCell"; title = "Select…"; ObjectID = "3385"; */
 "3385.title" = "選擇…";
 
@@ -36,7 +36,7 @@
 /* Class = "NSMenuItem"; title = "Black and White"; ObjectID = "1353"; */
 "1353.title" = "黑白";
 /* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "1354"; */
-"1354.title" = "與檔案設定一致";
+"1354.title" = "與文件設定一致";
 /* Class = "NSButtonCell"; title = "Print background"; ObjectID = "P53-bb-aGF"; */
 "P53-bb-aGF.title" = "列印背景";
 
@@ -46,7 +46,7 @@
 /* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "946"; */
 "946.title" = "不列印";
 /* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "947"; */
-"947.title" = "與檔案設定一致";
+"947.title" = "與文件設定一致";
 /* Class = "NSMenuItem"; title = "Print"; ObjectID = "948"; */
 "948.title" = "列印";
 
@@ -55,7 +55,7 @@
 /* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "952"; */
 "952.title" = "不列印";
 /* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "953"; */
-"953.title" = "與檔案設定一致";
+"953.title" = "與文件設定一致";
 /* Class = "NSMenuItem"; title = "Print"; ObjectID = "954"; */
 "954.title" = "列印";
 
@@ -72,7 +72,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "uuc-7D-Iot"; */
 "uuc-7D-Iot.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "896"; */
-"896.title" = "檔案名稱";
+"896.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "897"; */
 "897.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "898"; */
@@ -94,7 +94,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "plk-U5-NGA"; */
 "plk-U5-NGA.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "902"; */
-"902.title" = "檔案名稱";
+"902.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "903"; */
 "903.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "904"; */
@@ -120,7 +120,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "Mvg-wT-FTM"; */
 "Mvg-wT-FTM.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "937"; */
-"937.title" = "檔案名稱";
+"937.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "938"; */
 "938.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "939"; */
@@ -142,7 +142,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "ckJ-Cw-ccE"; */
 "ckJ-Cw-ccE.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "929"; */
-"929.title" = "檔案名稱";
+"929.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "930"; */
 "930.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "931"; */

--- a/CotEditor/zh-Hant.lproj/PrintPanelAccessory.strings
+++ b/CotEditor/zh-Hant.lproj/PrintPanelAccessory.strings
@@ -29,7 +29,7 @@
 /* Class = "NSMenuItem"; title = "Black and White"; ObjectID = "590"; */
 "590.title" = "黑白";
 /* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "589"; */
-"589.title" = "與檔案設定一致";
+"589.title" = "與文件設定一致";
 /* Class = "NSButtonCell"; title = "Print background"; ObjectID = "Jff-bZ-Xbm"; */
 "Jff-bZ-Xbm.title" = "列印背景";
 
@@ -38,14 +38,14 @@
 /* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "420"; */
 "420.title" = "不列印";
 /* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "419"; */
-"419.title" = "與檔案設定一致";
+"419.title" = "與文件設定一致";
 /* Class = "NSMenuItem"; title = "Print"; ObjectID = "418"; */
 "418.title" = "列印";
 
 /* Class = "NSTextFieldCell"; title = "Invisibles:"; ObjectID = "718"; */
 "718.title" = "不可見元素：";
 /* Class = "NSMenuItem"; title = "Same as Document’s Setting"; ObjectID = "427"; */
-"427.title" = "與檔案設定一致";
+"427.title" = "與文件設定一致";
 /* Class = "NSMenuItem"; title = "Don’t Print"; ObjectID = "428"; */
 "428.title" = "不列印";
 /* Class = "NSMenuItem"; title = "Print"; ObjectID = "426"; */
@@ -64,7 +64,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "UJ5-ki-qHL"; */
 "UJ5-ki-qHL.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "202"; */
-"202.title" = "檔案名稱";
+"202.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "203"; */
 "203.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "206"; */
@@ -87,7 +87,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "6RR-gp-tKJ"; */
 "6RR-gp-tKJ.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "312"; */
-"312.title" = "檔案名稱";
+"312.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "307"; */
 "307.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "311"; */
@@ -113,7 +113,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "Ro5-rK-S7p"; */
 "Ro5-rK-S7p.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "320"; */
-"320.title" = "檔案名稱";
+"320.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "315"; */
 "315.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "319"; */
@@ -135,7 +135,7 @@
 /* Class = "NSMenuItem"; title = "Syntax Name"; ObjectID = "i9p-3e-KNC"; */
 "i9p-3e-KNC.title" = "文法名";
 /* Class = "NSMenuItem"; title = "Document Name"; ObjectID = "328"; */
-"328.title" = "檔案名稱";
+"328.title" = "文件名稱";
 /* Class = "NSMenuItem"; title = "File Path"; ObjectID = "323"; */
 "323.title" = "檔案路徑";
 /* Class = "NSMenuItem"; title = "Print Date"; ObjectID = "327"; */

--- a/CotEditor/zh-Hant.lproj/ServicesMenu.strings
+++ b/CotEditor/zh-Hant.lproj/ServicesMenu.strings
@@ -25,4 +25,4 @@
 //
 
 "New CotEditor Document with Selection" = "使用選中內容創建新的CotEditor文件";
-"Open File in CotEditor" = "在CotEditor中打開檔案";
+"Open File in CotEditor" = "在CotEditor中開啟檔案";

--- a/CotEditor/zh-Hant.lproj/SyntaxCompletionsEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxCompletionsEditView.strings
@@ -25,7 +25,7 @@
 //
 
 /* Class = "NSTextFieldCell"; title = "If no word, the completion list will be generated from coloring settings."; ObjectID = "fJg-PK-TBB"; */
-"fJg-PK-TBB.title" = "如果沒有單詞，補全列表將由高亮設定生成。";
+"fJg-PK-TBB.title" = "如果沒有單字，補全列表將由高亮設定生成。";
 
 /* Class = "NSTableColumn"; headerCell.title = "Completions"; ObjectID = "uGV-wD-V9T"; */
 "uGV-wD-V9T.headerCell.title" = "補全";

--- a/CotEditor/zh-Hant.lproj/SyntaxFileMappingEditView.strings
+++ b/CotEditor/zh-Hant.lproj/SyntaxFileMappingEditView.strings
@@ -43,7 +43,7 @@
 /* Class = "NSTextFieldCell"; title = "Interpreters"; ObjectID = "Axx-Oq-E9U"; */
 "Axx-Oq-E9U.title" = "直譯器";
 /* Class = "NSTextFieldCell"; title = "The interpreters are used to determine the syntax style from the shebang in the document."; ObjectID = "dIj-Z5-J2j"; */
-"dIj-Z5-J2j.title" = "直譯器將根據檔案整體來決定文法高亮樣式。";
+"dIj-Z5-J2j.title" = "直譯器將根據文件整體來決定文法高亮樣式。";
 
 /* Class = "NSTableColumn"; headerCell.title = "Interpreter"; ObjectID = "I6J-y5-MxO"; */
 "I6J-y5-MxO.headerCell.title" = "直譯器";


### PR DESCRIPTION
4.2.1 のおかげで、（zh-Hant 翻訳についての）訂正する必要のあるところは より安く見えるようになりました。
故にこの訂正用PRです。
よろしくお願い致します。
