### PR TITLE
Fixed typo in script_menu.html

### DIFF
--- a/CotEditor/CotEditor.help/Contents/Resources/en.lproj/pgs/script_menu.html
+++ b/CotEditor/CotEditor.help/Contents/Resources/en.lproj/pgs/script_menu.html
@@ -73,7 +73,7 @@
 <table>
 	<caption>Examples</caption>
 	<thead>
-		<tr><th>Filename</th><th>Display in the menu</th><th>Sortcut</th></tr>
+		<tr><th>Filename</th><th>Display in the menu</th><th>Shortcut</th></tr>
 	</thead>
 	<tbody>
 		<tr>

--- a/CotEditor/it.lproj/ReportTemplate.md
+++ b/CotEditor/it.lproj/ReportTemplate.md
@@ -1,5 +1,5 @@
 
-Compilare il template che segue, e caricarlo su [GitHub Issues](https://github.com/coteditor/CotEditor/issues) oppure inviarlo a <coteditor.github@gmail.com>. Si prega di notare che i contenuti della email inviata potrebbero essere condivisi sulla pagina dedicata alla risoluzione dei problemi (Issues). Please write the contents either in English or in Japanese.
+Compilare il template che segue, e caricarlo su [GitHub Issues](https://github.com/coteditor/CotEditor/issues) oppure inviarlo a <coteditor.github@gmail.com>. Si prega di notare che i contenuti della email inviata potrebbero essere condivisi sulla pagina dedicata alla risoluzione dei problemi (Issues). Scrivere il contenuto in inglese o giapponese.
 
 -----------------------------------------------
 


### PR DESCRIPTION
Fixed typo in script_menu.html

Also, translated a sentence that was still in English in the file ReportTemplate.md (Italian)