### PR TITLE
Fix codeblock regex for Markdown

### DIFF
--- a/CotEditor/Syntaxes/Markdown.yml
+++ b/CotEditor/Syntaxes/Markdown.yml
@@ -105,7 +105,7 @@ characters:
 - beginString: "(?<!\\\\)(\\`{1,2})[^ \\t`]((?!\\R{2})(?:.|\\R))*?(?<![\\\\ ])\\1"
   description: "code"
   regularExpression: true
-- beginString: "^[~]{3,}[{[:space:]](?!~~~)(?:.|\\R)*?\\R[\\t ]*[~]{3,}[\\t ]*$"
+- beginString: "(?:\R{2,}|\A)((?:([ ]{4}|\t)(.*(?:\R+|\Z)))+)((?=^[ ]{0,4}\S)|\Z)"
   description: "[extra] codeblock"
   regularExpression: true
 - beginString: "^```[^`](?!```)(?:.|\\R)*?\\R[\\t ]*```"


### PR DESCRIPTION
Code block highlighting for the Markdown language wasn't working for me, when relying on indentation with four or more spaces.

I had to replace the regular expression with the one suggested on this PR.

Reference:

* https://stackoverflow.com/a/63082323/2619107

Thanks for this beautiful text editor.