### PR TITLE
Remove redundant attributes array

### DIFF
--- a/CotEditor/Syntaxes/C++.yml
+++ b/CotEditor/Syntaxes/C++.yml
@@ -129,7 +129,6 @@ attributes:
 - beginString: "#pragma"
 - beginString: "#undef"
 commands: []
-attributes: []
 values:
 - beginString: "false"
 - beginString: "NULL"


### PR DESCRIPTION
Hello, and thank you for this wonderful project!

In the syntax style file for C++, there is a redundant attributes array, preventing the attributes from highlighting as intended. Removing the redundant array fixes the issue for me.

I am new to submitting pull requests, so I hope this is helpful and done correctly!