### PR TITLE
Fixed the positioning of some strings translated into Italian

### DIFF
--- a/CotEditor/it.lproj/Localizable.strings
+++ b/CotEditor/it.lproj/Localizable.strings
@@ -102,17 +102,17 @@
 "Not replaced" = "Non sostituiti";
 
 // pairs of checkbox label and its tooltip
-"Regular Expression" = "Ignora maiuscole/minuscole";
-"Select to search with regular expression." = "Selezionare per ignorare maiuscole/minuscole nella ricerca.";
+"Regular Expression" = "Espressioni regolari";
+"Select to search with regular expression." = "Selezionare per ricercare con le espressioni regolari.";
 
-"Ignore Case" = "In selezione";
-"Select to ignore character case on search." = "Selezionare per ricercare testo solo all’interno della selezione.";
+"Ignore Case" = "Ignora maiuscole/minuscole";
+"Select to ignore character case on search." = "Selezionare per ignorare maiuscole/minuscole nella ricerca.";
 
-"In Selection" = "Limita alla selezione";
-"Select to search text only from selection." = "Mostra un riferimento rapido per la sintassi delle espressioni regolari.";
+"In Selection" = "In selezione";
+"Select to search text only from selection." = "Selezionare per ricercare testo solo all’interno della selezione.";
 
 // tooltip for regex help button
-"Show quick reference for regular expression syntax." = "Show quick reference for regular expression syntax.";
+"Show quick reference for regular expression syntax." = "Mostra un riferimento rapido per la sintassi delle espressioni regolari.";
 
 // pair of accessibility label for a image button and its tooltip
 "Advanced options" = "Opzioni avanzate";

--- a/CotEditor/it.lproj/Localizable.strings
+++ b/CotEditor/it.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Find previous match." = "Cerca l’occorrenza precedente.";
 
 "Find Next" = "Cerca successivo";
-"Find next match." = "Cerca l’occorrenza successivo.";
+"Find next match." = "Cerca l’occorrenza successiva.";
 
 
 


### PR DESCRIPTION
Fixed the positioning of some strings translated into Italian.

Update Localizable.strings (Italian)

See https://github.com/coteditor/CotEditor/commit/a57c488f85958ed9540f2b89ec0a8b268c943eeb#diff-b447e3fe9de7c691bd014b020ece0e866f2cd7e5b2820351738602ee72303762