### PR TITLE
Update interpreters for Lisp, Lua, Scheme, and Tcl.

### DIFF
--- a/CotEditor/Syntaxes/Lisp.yml
+++ b/CotEditor/Syntaxes/Lisp.yml
@@ -36,7 +36,7 @@ extensions:
 - keyString: edn
 filenames: []
 interpreters:
-- keyString: lua
+- keyString: sbcl
 keywords:
 - beginString: (?<=\()[^[:space:],)]+
   regularExpression: true

--- a/CotEditor/Syntaxes/Lua.yml
+++ b/CotEditor/Syntaxes/Lua.yml
@@ -277,7 +277,9 @@ completions: []
 extensions:
 - keyString: lua
 filenames: []
-interpreters: []
+interpreters:
+- keyString: lua
+- keyString: luajit
 keywords:
 - beginString: and
 - beginString: break

--- a/CotEditor/Syntaxes/Scheme.yml
+++ b/CotEditor/Syntaxes/Scheme.yml
@@ -343,7 +343,11 @@ extensions:
 - keyString: ss
 filenames: []
 interpreters:
-- keyString: tclsh
+- keyString: chicken-scheme
+- keyString: csi
+- keyString: gosh
+- keyString: guile
+- keyString: gsi
 keywords:
 - beginString: =>
 - beginString: and

--- a/CotEditor/Syntaxes/Tcl.yml
+++ b/CotEditor/Syntaxes/Tcl.yml
@@ -1296,7 +1296,10 @@ completions: []
 extensions:
 - keyString: tcl
 filenames: []
-interpreters: []
+interpreters:
+- keyString: jimsh
+- keyString: tclsh
+- keyString: wish
 keywords: []
 kind: code
 metadata:


### PR DESCRIPTION
There seems to be an oversight for the interpreters for Lisp (`Lua`, which should be for Lua instead) and Scheme (`tclsh`, which should be for Tcl instead). This PR fixes these assignments and added some other commonly used interpreters for these languages as well.