### PR TITLE
Use a transparent title bar for Find & Replace window

### DIFF
--- a/CotEditor/Sources/Text Finder/Views/FindPanelController.swift
+++ b/CotEditor/Sources/Text Finder/Views/FindPanelController.swift
@@ -39,6 +39,7 @@ final class FindPanelController: NSWindowController, NSWindowDelegate {
         let window = NSPanel(contentViewController: FindPanelContentViewController())
         window.styleMask = [.titled, .closable, .resizable, .utilityWindow]
         window.level = .floating
+        window.titlebarAppearsTransparent = true
         window.autorecalculatesKeyViewLoop = true
         window.standardWindowButton(.zoomButton)?.isEnabled = false
         window.title = String(localized: "Find & Replace", table: "TextFind", comment: "window title")


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="457" alt="Screenshot 2024-12-17 at 23 10 54" src="https://github.com/user-attachments/assets/67778800-778c-4aa6-bb46-82be67d734f0" />|<img width="457" alt="Screenshot 2024-12-17 at 23 10 33" src="https://github.com/user-attachments/assets/3086cd3e-3367-4553-81de-d13d6f5f31f1" />|