### PR TITLE
Update Go.yml

### DIFF
--- a/CotEditor/Resources/Syntaxes/Go.yml
+++ b/CotEditor/Resources/Syntaxes/Go.yml
@@ -14,8 +14,8 @@ commands:
 - beginString: make
 - beginString: new
 - beginString: panic
-- beginString: print
-- beginString: println
+- beginString: Print
+- beginString: Println
 - beginString: real
 - beginString: recover
 commentDelimiters:


### PR DESCRIPTION
Fixed issue #1821 with the wrong spelling of `print` and `println`