### PR TITLE
HTML ARIA Attributes

### DIFF
--- a/CotEditor/Resources/Syntaxes/HTML.yml
+++ b/CotEditor/Resources/Syntaxes/HTML.yml
@@ -32,6 +32,9 @@ attributes:
 - beginString: (?<=\s)archive(?=\b[^<>]*>)
   ignoreCase: true
   regularExpression: true
+- beginString: (?<=\s)aria-[a-z\-]+(?=\b[^<>]*>)
+  ignoreCase: true
+  regularExpression: true
 - beginString: (?<=\s)async(?=\b[^<>]*>)
   ignoreCase: true
   regularExpression: true


### PR DESCRIPTION
Added syntax highlighting for HTML **aria attributes** as mentioned in issue #1862