### PR TITLE
Syntax Highlighting: CSS Color Spaces

### DIFF
--- a/CotEditor/Resources/Syntaxes/CSS.yml
+++ b/CotEditor/Resources/Syntaxes/CSS.yml
@@ -165,6 +165,10 @@ characters:
   regularExpression: true
 - beginString: invert(?=\()
   regularExpression: true
+- beginString: lab(?=\()
+  regularExpression: true
+- beginString: lch(?=\()
+  regularExpression: true
 - beginString: linear-gradient(?=\()
   regularExpression: true
 - beginString: local(?=\()
@@ -176,6 +180,10 @@ characters:
 - beginString: max(?=\()
   regularExpression: true
 - beginString: min(?=\()
+  regularExpression: true
+- beginString: oklab(?=\()
+  regularExpression: true
+- beginString: oklch(?=\()
   regularExpression: true
 - beginString: opacity(?=\()
   regularExpression: true


### PR DESCRIPTION
Added syntax highlighting for the following color spaces:

- [lab](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lab)
- [oklab](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklab)
- [lch](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lch)
- [oklch](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch)