### PR TITLE
Go Syntax Highlighting: Added built-in functions

### DIFF
--- a/CotEditor/Resources/Syntaxes/Go.yml
+++ b/CotEditor/Resources/Syntaxes/Go.yml
@@ -9,13 +9,24 @@ commands:
 - beginString: complex
 - beginString: copy
 - beginString: delete
+- beginString: Errorf
+- beginString: Fatalf
+- beginString: Fprint
+- beginString: Fprintf
+- beginString: Fprintln
+- beginString: FScan
+- beginString: FScanf
+- beginString: FScanln
 - beginString: imag
 - beginString: len
 - beginString: make
 - beginString: new
 - beginString: panic
 - beginString: Print
+- beginString: Printf
 - beginString: Println
+- beginString: Sprintf
+- beginString: Sprintln
 - beginString: real
 - beginString: recover
 commentDelimiters:


### PR DESCRIPTION
Hi, the Go standard library has tons of built-in functions that are not currently highlighted in CotEditor.

I have added a few functions that I will be using for an upcoming project within the [fmt package](https://pkg.go.dev/fmt@go1.24.6#pkg-functions).