### PR TITLE
Add LSFileQuarantineEnabled value to Info.plist

### DIFF
--- a/CotEditor/Info.plist
+++ b/CotEditor/Info.plist
@@ -1465,5 +1465,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>LSFileQuarantineEnabled</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
According to [the Apple documentation](https://developer.apple.com/documentation/bundleresources/information-property-list/lsfilequarantineenabled), setting this value to false prevents macOS from automatically quarantining every file CotEditor saves. This prevents problems like #1216. I have tested this by saving a script from CotEditor using the save-as-executable option, and it runs from the Terminal without complaint.