### PR TITLE
Update Polish localization for CotEditor 6.1.0 (#1956)

### DIFF
--- a/CotEditor/Localizables/Application/Localizable.xcstrings
+++ b/CotEditor/Localizables/Application/Localizable.xcstrings
@@ -435,7 +435,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dodaj nowy element"
+            "value" : "Dodaj nową pozycję"
           }
         },
         "pt" : {
@@ -625,7 +625,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usuń wybrane elementy"
+            "value" : "Usuń zaznaczone pozycje"
           }
         },
         "pt" : {
@@ -8530,7 +8530,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wybrano wiele elementów"
+            "value" : "Wybrano wiele pozycji"
           }
         },
         "pt" : {
@@ -8625,7 +8625,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nie wybrano żadnego elementu"
+            "value" : "Nie wybrano żadnej pozycji"
           }
         },
         "pt" : {

--- a/CotEditor/Localizables/Document Window/Document.xcstrings
+++ b/CotEditor/Localizables/Document Window/Document.xcstrings
@@ -7848,6 +7848,12 @@
             "value" : "Zoeken in map…"
           }
         },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyszukiwanie w folderze…"
+          }
+        },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",

--- a/CotEditor/Localizables/Panels/WhatsNew.xcstrings
+++ b/CotEditor/Localizables/Panels/WhatsNew.xcstrings
@@ -243,6 +243,12 @@
             "value" : "Het gedrag van opmerkingen kan nu worden aangepast, waardoor de editor natuurlijker aanvoelt in het gebruik."
           }
         },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teraz możesz dostosować zachowanie komentarzy, dzięki czemu korzystanie z edytora stanie się bardziej naturalne."
+          }
+        },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
@@ -334,6 +340,12 @@
             "value" : "Meer slimme opmerkingen uit"
           }
         },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bardziej sprytne komentowanie"
+          }
+        },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
@@ -423,6 +435,12 @@
             "value" : "De bestandskiezer maakt het nu mogelijk om items op bestandsnaam te filteren."
           }
         },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przeglądarka plików umożliwia teraz filtrowanie pozycji według nazw plików."
+          }
+        },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
@@ -510,6 +528,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Zoek documenten in de bestandskiezer"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Znajdź dokumenty w przeglądarce plików"
           }
         },
         "pt" : {

--- a/CotEditor/Localizables/Settings/Panes/EditSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/EditSettings.xcstrings
@@ -63,6 +63,12 @@
             "value" : "Voeg een spatie toe aan de commentaarscheidingstekens"
           }
         },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodawaj spację do ograniczników komentarza"
+          }
+        },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1199,6 +1205,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Voeg commentaarscheidingstekens in na inspringing"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wstawiaj ograniczniki komentarzy po wcięciu"
           }
         },
         "pt" : {

--- a/CotEditor/Localizables/Settings/Panes/FormatSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/FormatSettings.xcstrings
@@ -588,7 +588,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Edytuj zaznaczoną rzecz"
+            "value" : "Edytuj zaznaczoną pozycję"
           }
         },
         "pt" : {


### PR DESCRIPTION
This update also unifies the translation of `item` in the `Action.add.tooltip`, `Action.delete.tooltip`, and `Action.edit.label` tooltips used in the `Settings` dialog and the `Multiple Replace` dialog, as well as in the `ItemSelection.multiple.message` and `ItemSelection.zero.message` used in the `Settings` dialog (`Format` > (available) syntax > `Outline` and `Snippets`).