### PR TITLE
Update Polish localization for CotEditor 6.2.0 (#1981)

### DIFF
--- a/CotEditor/Localizables/Panels/SettingsPorting.xcstrings
+++ b/CotEditor/Localizables/Panels/SettingsPorting.xcstrings
@@ -1453,7 +1453,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Definicje wielokrotnych zastąpień"
           }
         },


### PR DESCRIPTION
Review `Multiple Replace Definitions`.