### PR TITLE
Correct decimal point in editor settings to respect user region setting

### DIFF
--- a/CotEditor/Sources/Settings Window/Panes/AppearanceSettingsView.swift
+++ b/CotEditor/Sources/Settings Window/Panes/AppearanceSettingsView.swift
@@ -102,7 +102,7 @@ struct AppearanceSettingsView: View {
                     .accessibilityLabeledPair(role: .label, id: "lineHeight", in: self.accessibility)
                 
                 HStack(alignment: .firstTextBaseline) {
-                    Stepper(value: $lineHeight, in: 0.1...10, step: 0.1, format: .number.precision(.fractionLength(1...2)), label: EmptyView.init)
+                    Stepper(value: $lineHeight, in: 0.1...10, step: 0.1, format: .number.precision(.fractionLength(1...2)).locale(Locale(languageCode: Locale.current.language.languageCode, languageRegion: Locale.current.region)), label: EmptyView.init)
                         .monospacedDigit()
                         .multilineTextAlignment(self.layoutDirection == .rightToLeft ? .leading : .trailing)
                         .accessibilityValue(String(localized: "\(self.lineHeight, format: .number) times", table: "AppearanceSettings",

--- a/CotEditor/Sources/Settings Window/Panes/EditSettingsView.swift
+++ b/CotEditor/Sources/Settings Window/Panes/EditSettingsView.swift
@@ -120,7 +120,7 @@ struct EditSettingsView: View {
                     HStack(alignment: .firstTextBaseline) {
                         Text("Delay:", tableName: "EditSettings")
                             .accessibilityLabeledPair(role: .label, id: "selectionInstanceHighlightDelay", in: self.accessibility)
-                        Stepper(value: $selectionInstanceHighlightDelay, in: 0...10, step: 0.25, format: .number.precision(.fractionLength(2)), label: EmptyView.init)
+                        Stepper(value: $selectionInstanceHighlightDelay, in: 0...10, step: 0.25, format: .number.precision(.fractionLength(2)).locale(Locale(languageCode: Locale.current.language.languageCode, languageRegion: Locale.current.region)), label: EmptyView.init)
                             .monospacedDigit()
                             .multilineTextAlignment(self.layoutDirection == .rightToLeft ? .leading : .trailing)  // width: 40
                             .accessibilityValue(Duration.seconds(self.selectionInstanceHighlightDelay)


### PR DESCRIPTION
This fix is ​​limited to respecting user settings at the `System Settings...` > `General` > `Language & Region` > `Region` level but not at the ... > `Number format` level.