### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   macOS:
     runs-on: macos-26


### PR DESCRIPTION
Potential fix for [https://github.com/coteditor/CotEditor/security/code-scanning/1](https://github.com/coteditor/CotEditor/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/Test.yml`, directly under `on:` and before `jobs:`.  
Use the minimum required permission for this workflow:

- `contents: read`

This preserves existing functionality (checkout + build/test) while ensuring `GITHUB_TOKEN` cannot get broader access via repo/org defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
