### PR TITLE
Add Search in Folder

### DIFF
--- a/CotEditor/Sources/Application/AppDelegate.swift
+++ b/CotEditor/Sources/Application/AppDelegate.swift
@@ -108,6 +108,7 @@ extension Logger {
     private weak var exportSettingsPanel: NSPanel?
     
     @IBOutlet private weak var encodingsMenu: NSMenu?
+    @IBOutlet private weak var findMenu: NSMenu?
     @IBOutlet private weak var syntaxesMenu: NSMenu?
     @IBOutlet private weak var lineEndingsMenu: NSMenu?
     @IBOutlet private weak var themesMenu: NSMenu?
@@ -476,6 +477,16 @@ extension Logger {
         assert(NSApp.mainMenu != nil)
         
         guard self.menuUpdateObservers.isEmpty else { return assertionFailure() }
+        
+        if let findMenu,
+           findMenu.indexOfItem(withTarget: nil, andAction: #selector(WindowContentViewController.searchInFolder)) == -1,
+           let findAllIndex = findMenu.items.firstIndex(where: { $0.tag == TextFinder.Action.findAll.rawValue })
+        {
+            findMenu.insertItem(NSMenuItem(title: String(localized: "Search in Folder…", table: "MainMenu", comment: "menu item label"),
+                                           systemImage: "folder",
+                                           action: #selector(WindowContentViewController.searchInFolder)),
+                                at: findAllIndex + 1)
+        }
         
         self.updateEncodingMenu(self.encodingsMenu!)
         

--- a/CotEditor/Sources/Document Window/WindowContentViewController.swift
+++ b/CotEditor/Sources/Document Window/WindowContentViewController.swift
@@ -50,6 +50,7 @@ final class WindowContentViewController: NSSplitViewController, NSToolbarItemVal
     private var versionBrowserObservers: [any NSObjectProtocol] = []
     
     private var defaultsObserver: AnyCancellable?
+    private var folderTextSearchPanelController: FolderTextSearchPanelController?
     
     
     // MARK: Split View Controller Methods
@@ -293,6 +294,13 @@ final class WindowContentViewController: NSSplitViewController, NSToolbarItemVal
                     ? String(localized: "Hide Status Bar", table: "MainMenu")
                     : String(localized: "Show Status Bar", table: "MainMenu")
                 
+            case #selector(searchInFolder):
+                (item as? NSMenuItem)?.toolTip = (self.directoryDocument == nil)
+                    ? String(localized: "Search in Folder is only available when a folder is opened as a document.",
+                             table: "MainMenu", comment: "tooltip for the “Search in Folder” menu item")
+                    : nil
+                return self.directoryDocument?.fileURL != nil
+                
             default: break
         }
         
@@ -370,6 +378,18 @@ final class WindowContentViewController: NSSplitViewController, NSToolbarItemVal
     @IBAction func toggleStatusBar(_ sender: Any?) {
         
         UserDefaults.standard[.showStatusBar].toggle()
+    }
+    
+    
+    /// Shows the search-in-folder panel.
+    @IBAction func searchInFolder(_ sender: Any?) {
+        
+        guard let directoryDocument else { return }
+        
+        let controller = self.folderTextSearchPanelController ?? FolderTextSearchPanelController(directoryDocument: directoryDocument)
+        self.folderTextSearchPanelController = controller
+        controller.showWindow(sender)
+        controller.window?.makeKeyAndOrderFront(sender)
     }
     
     

--- a/CotEditor/Sources/Text Finder/FolderTextSearchPanelController.swift
+++ b/CotEditor/Sources/Text Finder/FolderTextSearchPanelController.swift
@@ -1,0 +1,260 @@
+//
+//  FolderTextSearchPanelController.swift
+//  CotEditor
+//
+//  ---------------------------------------------------------------------------
+//
+//  © 2026 sdraeger
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Combine
+import SwiftUI
+import Defaults
+import StringUtils
+import TextFind
+import URLUtils
+
+@MainActor final class FolderTextSearchPanelController: NSWindowController {
+    
+    private let model: FolderTextSearchModel
+    
+    
+    init(directoryDocument: DirectoryDocument) {
+        
+        let rootURL = directoryDocument.fileURL!
+        let model = FolderTextSearchModel(rootURL: rootURL) { [weak directoryDocument] match in
+            guard let directoryDocument else { return }
+            
+            Task {
+                guard
+                    await directoryDocument.openDocument(at: match.fileURL, asPlainText: true),
+                    let document = directoryDocument.currentDocument as? Document,
+                    let textView = document.textView,
+                    textView.string.length >= match.range.upperBound
+                else { return }
+                
+                textView.selectedRange = match.range
+                textView.scrollRangeToVisible(match.range)
+                textView.showFindIndicator(for: match.range)
+                directoryDocument.fileBrowserViewController?.selectCurrentDocument()
+            }
+        }
+        self.model = model
+        
+        let hostingController = NSHostingController(rootView: FolderTextSearchView(model: model))
+        let window = NSPanel(contentViewController: hostingController)
+        window.title = String(localized: "Search in Folder", table: "TextFind", comment: "window title")
+        window.styleMask.insert([.closable, .miniaturizable, .resizable])
+        window.collectionBehavior.insert(.fullScreenAuxiliary)
+        window.isReleasedWhenClosed = false
+        window.setContentSize(NSSize(width: 760, height: 460))
+        
+        super.init(window: window)
+    }
+    
+    
+    required init?(coder: NSCoder) {
+        
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+@MainActor final class FolderTextSearchModel: ObservableObject {
+    
+    @Published var findString: String
+    @Published var usesRegularExpression: Bool {
+        
+        didSet { UserDefaults.standard[.findUsesRegularExpression] = self.usesRegularExpression }
+    }
+    @Published var ignoresCase: Bool {
+        
+        didSet { UserDefaults.standard[.findIgnoresCase] = self.ignoresCase }
+    }
+    @Published var includesHiddenFiles: Bool
+    @Published var matches: [FolderTextSearch.Match] = []
+    @Published var isSearching = false
+    @Published var didSearch = false
+    @Published var errorMessage: String?
+    
+    let rootURL: URL
+    
+    private var searchTask: Task<Void, Never>?
+    private let openMatch: (FolderTextSearch.Match) -> Void
+    
+    
+    init(rootURL: URL, openMatch: @escaping (FolderTextSearch.Match) -> Void) {
+        
+        let settings = TextFinderSettings.shared
+        
+        self.rootURL = rootURL
+        self.findString = settings.findString
+        self.usesRegularExpression = UserDefaults.standard[.findUsesRegularExpression]
+        self.ignoresCase = UserDefaults.standard[.findIgnoresCase]
+        self.includesHiddenFiles = UserDefaults.standard[.fileBrowserShowsHiddenFiles]
+        self.openMatch = openMatch
+    }
+    
+    
+    deinit {
+        
+        self.searchTask?.cancel()
+    }
+    
+    
+    var resultMessage: String {
+        
+        guard self.didSearch else { return self.rootURL.lastPathComponent }
+        
+        return String(localized: "\(self.matches.count) matches in “\(self.rootURL.lastPathComponent)”",
+                      table: "TextFind", comment: "folder search result count")
+    }
+    
+    
+    func search() {
+        
+        guard !self.findString.isEmpty else { return }
+        
+        self.searchTask?.cancel()
+        self.isSearching = true
+        self.didSearch = true
+        self.errorMessage = nil
+        self.matches = []
+        
+        let settings = TextFinderSettings.shared
+        settings.findString = self.findString
+        settings.noteFindHistory()
+        
+        let rootURL = self.rootURL
+        let findString = self.findString
+        let mode = settings.mode
+        let includesHiddenFiles = self.includesHiddenFiles
+        
+        self.searchTask = Task {
+            do {
+                let matches = try await FolderTextSearch.matches(in: rootURL,
+                                                                 findString: findString,
+                                                                 mode: mode,
+                                                                 options: FolderTextSearch.Options(includesHiddenFiles: includesHiddenFiles))
+                guard !Task.isCancelled else { return }
+                
+                self.matches = matches
+            } catch is CancellationError {
+                return
+            } catch {
+                self.errorMessage = error.localizedDescription
+            }
+            
+            self.isSearching = false
+        }
+    }
+    
+    
+    func selectMatch(id: FolderTextSearch.Match.ID?) {
+        
+        guard let match = self.matches[id: id] else { return }
+        
+        self.openMatch(match)
+    }
+}
+
+
+private struct FolderTextSearchView: View {
+    
+    @ObservedObject var model: FolderTextSearchModel
+    
+    @State private var selection: FolderTextSearch.Match.ID?
+    
+    
+    var body: some View {
+        
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                TextField(String(localized: "Find", table: "TextFind", comment: "placeholder"),
+                          text: self.$model.findString)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { self.model.search() }
+                
+                ProgressView()
+                    .controlSize(.small)
+                    .opacity(self.model.isSearching ? 1 : 0)
+                
+                Button(String(localized: "Search", table: "TextFind", comment: "button label"), systemImage: "magnifyingglass") {
+                    self.model.search()
+                }
+                .disabled(self.model.findString.isEmpty || self.model.isSearching)
+            }
+            
+            HStack {
+                Toggle(String(localized: "Regular Expression", table: "TextFind", comment: "toggle button label"),
+                       isOn: self.$model.usesRegularExpression)
+                Toggle(String(localized: "Ignore Case", table: "TextFind", comment: "toggle button label"),
+                       isOn: self.$model.ignoresCase)
+                Toggle(String(localized: "Hidden Files", table: "TextFind", comment: "toggle button label"),
+                       isOn: self.$model.includesHiddenFiles)
+                
+                Spacer()
+                
+                Text(self.model.errorMessage ?? self.model.resultMessage)
+                    .foregroundColor(self.model.errorMessage == nil ? .secondary : .red)
+                    .lineLimit(1)
+            }
+            
+            Table(self.model.matches, selection: self.$selection) {
+                TableColumn(String(localized: "File", table: "TextFind", comment: "table column header")) { match in
+                    Text(match.fileURL.path(relativeTo: self.model.rootURL))
+                        .truncationMode(.middle)
+                }
+                .width(min: 140, ideal: 220)
+                
+                TableColumn(String(localized: "Line", table: "TextFind", comment: "table column header")) { match in
+                    Text(match.lineNumber, format: .number)
+                        .monospacedDigit()
+                }
+                .width(ideal: 48, max: 72)
+                .alignment(.trailing)
+                
+                TableColumn(String(localized: "Matched Text", table: "TextFind", comment: "table column header")) { match in
+                    Text(AttributedString(match.attributedLineString(offset: 16)))
+                        .truncationMode(.tail)
+                }
+            }
+            .environment(\.defaultMinListRowHeight, 20)
+            .tableStyle(.bordered)
+            .onChange(of: self.selection) { _, newValue in
+                self.model.selectMatch(id: newValue)
+            }
+        }
+        .padding(12)
+        .frame(minWidth: 640, minHeight: 360)
+    }
+}
+
+
+private extension FolderTextSearch.Match {
+    
+    func attributedLineString(offset: Int) -> NSAttributedString {
+        
+        let attributedString = NSMutableAttributedString(string: self.lineString)
+        let inlineRange = NSRange(location: self.inlineLocation,
+                                  length: min(self.range.length, max(attributedString.length - self.inlineLocation, 0)))
+        if !inlineRange.isEmpty {
+            attributedString.addAttribute(.backgroundColor, value: NSColor.textHighlighterColor, range: inlineRange)
+        }
+        
+        return attributedString.truncatedHead(until: self.inlineLocation, offset: offset)
+    }
+}

--- a/CotEditor/Storyboards/Base.lproj/Main.storyboard
+++ b/CotEditor/Storyboards/Base.lproj/Main.storyboard
@@ -1273,6 +1273,7 @@ CA
                 <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="CotEditor" customModuleProvider="target">
                     <connections>
                         <outlet property="encodingsMenu" destination="300" id="Oy6-3l-RCI"/>
+                        <outlet property="findMenu" destination="kGA-vM-cdL" id="zMJ-zY-aQs"/>
                         <outlet property="lineEndingsMenu" destination="296" id="U4V-rN-Wn0"/>
                         <outlet property="multipleReplaceMenu" destination="OaT-5c-bMY" id="YLT-05-lBG"/>
                         <outlet property="normalizationMenu" destination="600" id="Ned-B7-VAN"/>

--- a/Packages/EditorCore/Package.swift
+++ b/Packages/EditorCore/Package.swift
@@ -76,7 +76,7 @@ let package = Package(
         .target(name: "TextEditing", dependencies: ["StringUtils"]),
         .testTarget(name: "TextEditingTests", dependencies: ["TextEditing"]),
         
-        .target(name: "TextFind", dependencies: ["StringUtils", "ValueRange"]),
+        .target(name: "TextFind", dependencies: ["FileEncoding", "StringUtils", "ValueRange"]),
         .testTarget(name: "TextFindTests", dependencies: ["TextFind"]),
         
         .target(name: "URLUtils"),

--- a/Packages/EditorCore/Sources/TextFind/FolderTextSearch.swift
+++ b/Packages/EditorCore/Sources/TextFind/FolderTextSearch.swift
@@ -1,0 +1,299 @@
+//
+//  FolderTextSearch.swift
+//  TextFind
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  ---------------------------------------------------------------------------
+//
+//  © 2026 sdraeger
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+public import Foundation
+import FileEncoding
+import StringUtils
+import UniformTypeIdentifiers
+
+public enum FolderTextSearch {
+    
+    public struct Options: Equatable, Sendable {
+        
+        public static let defaultEncodingCandidates: [String.Encoding] = [
+            .utf8,
+            .utf16,
+            .utf16LittleEndian,
+            .utf16BigEndian,
+            .utf32,
+            .utf32LittleEndian,
+            .utf32BigEndian,
+            .isoLatin1,
+            .windowsCP1252,
+            .shiftJIS,
+        ]
+        
+        public var includesHiddenFiles: Bool
+        public var followsPackageDirectories: Bool
+        public var maximumFileSize: Int
+        public var maximumLineLength: Int
+        public var allowedFilenameExtensions: Set<String>?
+        public var excludedDirectoryNames: Set<String>
+        public var encodingCandidates: [String.Encoding]
+        
+        
+        public init(includesHiddenFiles: Bool = false,
+                    followsPackageDirectories: Bool = false,
+                    maximumFileSize: Int = 10 * 1024 * 1024,
+                    maximumLineLength: Int = 1024,
+                    allowedFilenameExtensions: Set<String>? = nil,
+                    excludedDirectoryNames: Set<String> = [".git", ".hg", ".svn"],
+                    encodingCandidates: [String.Encoding] = Self.defaultEncodingCandidates)
+        {
+            self.includesHiddenFiles = includesHiddenFiles
+            self.followsPackageDirectories = followsPackageDirectories
+            self.maximumFileSize = maximumFileSize
+            self.maximumLineLength = maximumLineLength
+            self.allowedFilenameExtensions = allowedFilenameExtensions.map {
+                Set($0.map(Self.normalizedPathExtension))
+            }
+            self.excludedDirectoryNames = excludedDirectoryNames
+            self.encodingCandidates = encodingCandidates
+        }
+        
+        
+        fileprivate static func normalizedPathExtension(_ pathExtension: String) -> String {
+            
+            pathExtension.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
+        }
+    }
+    
+    
+    public struct Match: Equatable, Identifiable, Sendable {
+        
+        public struct ID: Hashable, Sendable {
+            
+            public var filePath: String
+            public var location: Int
+            public var length: Int
+        }
+        
+        
+        public var fileURL: URL
+        public var range: NSRange
+        public var lineNumber: Int
+        public var lineFragmentRange: NSRange
+        public var inlineLocation: Int
+        public var lineString: String
+        
+        
+        public var id: ID {
+            
+            ID(filePath: self.fileURL.standardizedFileURL.path,
+               location: self.range.location,
+               length: self.range.length)
+        }
+        
+        
+        public init(fileURL: URL, range: NSRange, lineNumber: Int, lineFragmentRange: NSRange, inlineLocation: Int, lineString: String) {
+            
+            self.fileURL = fileURL
+            self.range = range
+            self.lineNumber = lineNumber
+            self.lineFragmentRange = lineFragmentRange
+            self.inlineLocation = inlineLocation
+            self.lineString = lineString
+        }
+    }
+    
+    
+    // MARK: Public Methods
+    
+    public static func matches(in rootURL: URL,
+                               findString: String,
+                               mode: TextFind.Mode,
+                               options: Options = Options()) async throws -> [Match]
+    {
+        try await Task.detached(priority: .userInitiated) {
+            try Self.search(rootURL: rootURL, findString: findString, mode: mode, options: options)
+        }.value
+    }
+    
+    
+    // MARK: Private Methods
+    
+    private static let resourceKeys: [URLResourceKey] = [
+        .contentTypeKey,
+        .fileSizeKey,
+        .isDirectoryKey,
+        .isHiddenKey,
+        .isPackageKey,
+        .isRegularFileKey,
+    ]
+    
+    
+    private static func search(rootURL: URL, findString: String, mode: TextFind.Mode, options: Options) throws -> [Match] {
+        
+        _ = try TextFind(for: "", findString: findString, mode: mode)
+        
+        let fileURLs = try Self.fileURLs(in: rootURL, options: options)
+        var matches: [Match] = []
+        
+        for fileURL in fileURLs {
+            try Task.checkCancellation()
+            guard let string = Self.string(at: fileURL, options: options) else { continue }
+            
+            let textFind = try TextFind(for: string, findString: findString, mode: mode)
+            var isCancelled = false
+            textFind.findAll { ranges, stop in
+                guard let matchedRange = ranges.first else { return }
+                
+                if Task.isCancelled {
+                    isCancelled = true
+                    stop = true
+                    return
+                }
+                
+                matches.append(Self.match(fileURL: fileURL, string: string, range: matchedRange, options: options))
+            }
+            
+            if isCancelled {
+                throw CancellationError()
+            }
+        }
+        
+        return matches.sorted { lhs, rhs in
+            let lhsPath = lhs.fileURL.standardizedFileURL.path
+            let rhsPath = rhs.fileURL.standardizedFileURL.path
+            if lhsPath != rhsPath {
+                return lhsPath.localizedStandardCompare(rhsPath) == .orderedAscending
+            }
+            return lhs.range.location < rhs.range.location
+        }
+    }
+    
+    
+    private static func fileURLs(in rootURL: URL, options: Options) throws -> [URL] {
+        
+        let rootURL = rootURL.standardizedFileURL
+        let rootResourceValues = try rootURL.resourceValues(forKeys: Set(Self.resourceKeys))
+        
+        guard rootResourceValues.isDirectory == true else {
+            return Self.acceptsFile(rootURL, values: rootResourceValues, options: options) ? [rootURL] : []
+        }
+        
+        let enumerationOptions: FileManager.DirectoryEnumerationOptions = options.includesHiddenFiles ? [] : [.skipsHiddenFiles]
+        guard let enumerator = FileManager.default.enumerator(at: rootURL,
+                                                              includingPropertiesForKeys: Self.resourceKeys,
+                                                              options: enumerationOptions,
+                                                              errorHandler: { _, _ in true })
+        else { return [] }
+        
+        var fileURLs: [URL] = []
+        for case let fileURL as URL in enumerator {
+            try Task.checkCancellation()
+            
+            let resourceValues = try fileURL.resourceValues(forKeys: Set(Self.resourceKeys))
+            if resourceValues.isDirectory == true {
+                if Self.skipsDirectory(fileURL, values: resourceValues, options: options) {
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
+            
+            if Self.acceptsFile(fileURL, values: resourceValues, options: options) {
+                fileURLs.append(fileURL)
+            }
+        }
+        
+        return fileURLs
+    }
+    
+    
+    private static func skipsDirectory(_ fileURL: URL, values: URLResourceValues, options: Options) -> Bool {
+        
+        if options.excludedDirectoryNames.contains(fileURL.lastPathComponent) {
+            return true
+        }
+        if !options.followsPackageDirectories, values.isPackage == true {
+            return true
+        }
+        
+        return false
+    }
+    
+    
+    private static func acceptsFile(_ fileURL: URL, values: URLResourceValues, options: Options) -> Bool {
+        
+        if !options.includesHiddenFiles, values.isHidden == true {
+            return false
+        }
+        if values.isRegularFile != true {
+            return false
+        }
+        if let fileSize = values.fileSize, fileSize > options.maximumFileSize {
+            return false
+        }
+        if let allowedFilenameExtensions = options.allowedFilenameExtensions,
+           !allowedFilenameExtensions.contains(Options.normalizedPathExtension(fileURL.pathExtension))
+        {
+            return false
+        }
+        if let contentType = values.contentType,
+           [.archive, .audio, .image, .movie].contains(where: contentType.conforms(to:))
+        {
+            return false
+        }
+        
+        return true
+    }
+    
+    
+    private static func string(at fileURL: URL, options: Options) -> String? {
+        
+        guard let data = try? Data(contentsOf: fileURL, options: .mappedIfSafe),
+              data.count <= options.maximumFileSize,
+              !Self.mayBeBinary(data)
+        else { return nil }
+        
+        let decodingOptions = String.DetectionOptions(candidates: options.encodingCandidates,
+                                                      considersDeclaration: true)
+        
+        return try? String.string(data: data, decodingStrategy: .automatic(decodingOptions)).0
+    }
+    
+    
+    private static func mayBeBinary(_ data: Data) -> Bool {
+        
+        data.prefix(4096).contains(0)
+    }
+    
+    
+    private static func match(fileURL: URL, string: String, range: NSRange, options: Options) -> Match {
+        
+        let nsString = string as NSString
+        let lineContentsRange = nsString.lineContentsRange(for: range)
+        let lineFragmentRange = lineContentsRange.clamped(around: range, maxLength: max(options.maximumLineLength, 1))
+        let lineString = nsString.substring(with: lineFragmentRange)
+        let lineNumber = string.lineNumber(at: range.location)
+        let inlineLocation = range.location - lineFragmentRange.location
+        
+        return Match(fileURL: fileURL,
+                     range: range,
+                     lineNumber: lineNumber,
+                     lineFragmentRange: lineFragmentRange,
+                     inlineLocation: inlineLocation,
+                     lineString: lineString)
+    }
+}

--- a/Packages/EditorCore/Tests/TextFindTests/FolderTextSearchTests.swift
+++ b/Packages/EditorCore/Tests/TextFindTests/FolderTextSearchTests.swift
@@ -1,0 +1,54 @@
+//
+//  FolderTextSearchTests.swift
+//  TextFindTests
+//
+//  CotEditor
+//  https://coteditor.com
+//
+//  ---------------------------------------------------------------------------
+//
+//  © 2026 sdraeger
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+@testable import TextFind
+
+struct FolderTextSearchTests {
+    
+    @Test func searchRecursivelyFindsTextMatches() async throws {
+        
+        let rootURL = FileManager.default.temporaryDirectory
+            .appending(component: UUID().uuidString, directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        
+        let nestedURL = rootURL.appending(component: "Nested", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+        
+        let firstURL = rootURL.appending(component: "first.txt")
+        let secondURL = nestedURL.appending(component: "second.md")
+        try "alpha\nNeedle beta\n".write(to: firstURL, atomically: true, encoding: .utf8)
+        try "prefix needle suffix\n".write(to: secondURL, atomically: true, encoding: .utf8)
+        
+        let matches = try await FolderTextSearch.matches(in: rootURL,
+                                                         findString: "needle",
+                                                         mode: .textual(options: .caseInsensitive, fullWord: false))
+        
+        #expect(matches.map { $0.fileURL.lastPathComponent } == ["first.txt", "second.md"])
+        #expect(matches.map(\.lineNumber) == [2, 1])
+        #expect(matches.map(\.inlineLocation) == [0, 7])
+        #expect(matches.map(\.lineString) == ["Needle beta", "prefix needle suffix"])
+    }
+}


### PR DESCRIPTION
Closes #1544.

## Summary
- Add a reusable `FolderTextSearch` engine that searches folder contents with CotEditor’s existing `TextFind` matching behavior.
- Add a Search in Folder panel for folder documents with regex, ignore-case, hidden-file options, result highlighting, and click-to-open navigation.
- Wire the Find menu to show Search in Folder only when a folder document is active.

## Test Plan
- [x] `git diff --check origin/main..HEAD`
- [x] `swift test` in `Packages/EditorCore`
- [x] `xcodebuild -project CotEditor.xcodeproj -scheme CotEditor -destination 'platform=macOS' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES build`
- [x] Manual: verified two folder-search results appear when Ignore Case is enabled for mixed-case `Needle` / `needle` test files.