### PR TITLE
docs<localization>: fixes in german localizations

### DIFF
--- a/CotEditor/Localizables/Panels/SettingsPorting.xcstrings
+++ b/CotEditor/Localizables/Panels/SettingsPorting.xcstrings
@@ -1778,7 +1778,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Definitionen für das Multiple Ersetzen"
+            "value" : "Definitionen für das multiple Ersetzen"
           }
         },
         "en" : {

--- a/CotEditor/Localizables/Settings/Panes/GeneralSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/GeneralSettings.xcstrings
@@ -2534,7 +2534,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Beim Verwenden einer Vorabversion werden ungeachtet dieser Einstellung immer nach neuen Vorabversionen gesucht."
+            "value" : "Beim Verwenden einer Vorabversion wird ungeachtet dieser Einstellung immer nach neuen Vorabversionen gesucht."
           }
         },
         "en-GB" : {

--- a/CotEditor/Localizables/Settings/Panes/ModeSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/ModeSettings.xcstrings
@@ -2268,7 +2268,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieses Syntax existiert nicht"
+            "value" : "Diese Syntax existiert nicht"
           }
         },
         "en-GB" : {


### PR DESCRIPTION
This pull request makes minor corrections to the German localization strings in several settings panels. The changes improve grammar and wording for better clarity and correctness.

Localization improvements:

* Corrected the phrase in `SettingsPorting.xcstrings` to use the proper lowercase for "multiple" in "Definitionen für das multiple Ersetzen".
* Fixed the sentence in `GeneralSettings.xcstrings` to use the correct singular verb form, improving grammatical accuracy.
* Updated the message in `ModeSettings.xcstrings` to use the correct gender for "Syntax", changing "Dieses Syntax" to "Diese Syntax".