### PR TITLE
Update Simplified Chinese localization for 7.1

### DIFF
--- a/CotEditor/Localizables/Document Window/Accessory Views/FileScopeEditor.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/FileScopeEditor.xcstrings
@@ -47,6 +47,12 @@
             "value" : "alle"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -99,6 +105,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "een of meer"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "任一"
           }
         },
         "zh-HK" : {
@@ -155,6 +167,12 @@
             "value" : "Komt overeen met"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合以下"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -207,6 +225,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "volgende voorwaarden:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条件："
           }
         },
         "zh-HK" : {
@@ -262,6 +286,12 @@
             "value" : "Het bereik bevat een regel zonder waarde."
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件范围中包含未设置值的规则。"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -313,6 +343,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Het bereik bevat een ongeldige reguliere expressie."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件范围中包含无效的正则表达式。"
           }
         },
         "zh-HK" : {
@@ -938,6 +974,12 @@
             "state" : "needs_review",
             "value" : "komt overeen met reguliere expressie"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匹配正则表达式"
+          }
         }
       }
     },
@@ -1430,6 +1472,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Bewaar als benoemd bereik…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存为命名范围…"
           }
         }
       }

--- a/CotEditor/Localizables/Document Window/Document.xcstrings
+++ b/CotEditor/Localizables/Document Window/Document.xcstrings
@@ -678,6 +678,12 @@
             "state" : "needs_review",
             "value" : "Wis bestandsbereik"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除文件范围"
+          }
         }
       }
     },
@@ -2783,6 +2789,12 @@
             "state" : "needs_review",
             "value" : "Wijzig bestandsbereik…"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑文件范围…"
+          }
         }
       }
     },
@@ -3258,6 +3270,12 @@
             "value" : "Filter voor bestandskiezer"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件浏览器过滤器"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3302,6 +3320,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Bestandsbereik"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件范围"
           }
         },
         "zh-HK" : {
@@ -4644,6 +4668,42 @@
             }
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@arg2@中的%#@arg1@"
+          },
+          "substitutions" : {
+            "arg1" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg个匹配项"
+                    }
+                  }
+                }
+              }
+            },
+            "arg2" : {
+              "argNum" : 2,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg个文件"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4840,6 +4900,12 @@
             "value" : "Geen overeenkomsten voor ‘%@’ gevonden."
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到“%@”的匹配项。"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5006,6 +5072,12 @@
             "value" : "Zoeken in map…"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在文件夹中搜索…"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5057,6 +5129,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "De map kan niet worden gevonden."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到文件夹。"
           }
         },
         "zh-HK" : {
@@ -5989,6 +6067,12 @@
             "value" : "Verborgen bestanden opnemen"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包括隐藏文件"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6034,6 +6118,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Andere bestandstypen opnemen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包括其他文件类型"
           }
         },
         "zh-HK" : {
@@ -7598,6 +7688,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Beheer bewaarde bereiken…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理已保存的范围…"
           }
         }
       }
@@ -10799,6 +10895,12 @@
             "value" : "Toon in bestandskiezer"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在文件浏览器中显示"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10843,6 +10945,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Bewaarde bereiken"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存的范围"
           }
         }
       }
@@ -11032,6 +11140,12 @@
             "value" : "Zoeken in map"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在文件夹中搜索"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11076,6 +11190,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Zoekmethode"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索方式"
           }
         },
         "zh-HK" : {
@@ -13187,6 +13307,12 @@
             "value" : "Volgende"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前进"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13238,6 +13364,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Ga naar het volgende document"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往下一个文稿"
           }
         },
         "zh-HK" : {
@@ -13293,6 +13425,12 @@
             "value" : "Geschiedenis"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "历史记录"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13344,6 +13482,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Vorige"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一个"
           }
         },
         "zh-HK" : {
@@ -13399,6 +13543,12 @@
             "value" : "Ga naar het vorige document"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往上一个文稿"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13450,6 +13600,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Ga terug of vooruit in de documentgeschiedenis"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在文稿历史记录中后退或前进"
           }
         },
         "zh-HK" : {

--- a/CotEditor/Localizables/Document Window/Document.xcstrings
+++ b/CotEditor/Localizables/Document Window/Document.xcstrings
@@ -13487,7 +13487,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上一个"
+            "value" : "后退"
           }
         },
         "zh-HK" : {

--- a/CotEditor/Localizables/Panels/WhatsNew.xcstrings
+++ b/CotEditor/Localizables/Panels/WhatsNew.xcstrings
@@ -258,6 +258,12 @@
             "state" : "needs_review",
             "value" : "Pas de inspringstijl naar wens per syntaxis aan in de Modusinstellingen."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用“模式”设置，按需为各个语法自定义缩进样式。"
+          }
         }
       }
     },
@@ -305,6 +311,12 @@
             "state" : "needs_review",
             "value" : "Inspringing passend bij elke syntaxis"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "适配各种语法的缩进"
+          }
         }
       }
     },
@@ -351,6 +363,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "In macOS 27 krijgen naamloze documenten automatisch een conceptnaam op basis van hun inhoud."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 macOS 27 中，系统会根据内容为未命名文稿自动建议一个草稿名称。"
           }
         },
         "zh-HK" : {
@@ -406,6 +424,12 @@
             "value" : "Laat het document zichzelf een naam geven"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "让文稿自行命名"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -457,6 +481,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Zoek tekst in bestanden in een geopende map, rechtstreeks vanuit de navigatiekolom."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直接在边栏中搜索已打开文件夹内的文本。"
           }
         },
         "zh-HK" : {
@@ -512,6 +542,12 @@
             "value" : "Vind het in de map"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在文件夹中查找"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -563,6 +599,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Gebruik de knoppenbalk om terug en vooruit te gaan door onlangs bekeken documenten in een mapdocument."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用工具栏在文件夹中前后浏览最近查看过的文稿。"
           }
         },
         "zh-HK" : {
@@ -618,6 +660,12 @@
             "value" : "Terug en vooruit in mappen"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在文件夹中前后浏览"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -671,6 +719,12 @@
             "value" : "CotEditor ondersteunt nu macOS 27 Golden Gate, inclusief een vernieuwde vormgeving voor het nieuwste systeem."
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CotEditor 现已支持 macOS 27 Golden Gate，并为最新系统带来全新外观。"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -722,6 +776,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Klaar voor macOS 27"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已为 macOS 27 准备就绪"
           }
         },
         "zh-HK" : {

--- a/CotEditor/Localizables/Settings/Other Views/SyntaxListCustomization.xcstrings
+++ b/CotEditor/Localizables/Settings/Other Views/SyntaxListCustomization.xcstrings
@@ -39,6 +39,12 @@
             "value" : "Verborgen syntaxen worden nog steeds gebruikt voor automatische detectie."
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏的语法仍会用于自动检测。"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
@@ -189,6 +195,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Selecteer de syntaxen die je in de Syntaxismenu’s wilt weergeven:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要在语法菜单中显示的语法："
           }
         },
         "zh-HK" : {

--- a/CotEditor/Localizables/Settings/Panes/FormatSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/FormatSettings.xcstrings
@@ -145,6 +145,12 @@
             "value" : "Pas syntaxismenu aan…"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义语法菜单…"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",

--- a/CotEditor/Storyboards/mul.lproj/Main.xcstrings
+++ b/CotEditor/Storyboards/mul.lproj/Main.xcstrings
@@ -25925,6 +25925,12 @@
             "value" : "Zoeken in map"
           }
         },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹查找"
+          }
+        },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",


### PR DESCRIPTION
## Summary

- Adds Simplified Chinese translations for all 43 strings requested in #2129, covering the What’s New panel, folder search, document-history navigation, file scopes, menu items, and syntax-menu customization.
- Aligns with the existing zh-Hans catalog and current macOS terminology, including 文稿, 文件夹, 边栏, 文件浏览器, and 正则表达式.
- Preserves the plural placeholders used by the folder-search result summary.

## Validation

- Parsed all six edited String Catalog files as JSON.
- Verified all 43 requested entries have translated zh-Hans values, including the plural substitutions.
- Ran `git diff --check`.

## Low-confidence wording for review

- `草稿名称` for the macOS 27 content-derived name given to untitled documents, and `文件范围` / `保存为命名范围…` for File Scope. These fit the screenshots and existing translations, but a project-specific preference would be easy to apply.

Refs #2129
