### PR TITLE
Align Simplified Chinese back navigation terminology

### DIFF
--- a/CotEditor/Localizables/Document Window/Document.xcstrings
+++ b/CotEditor/Localizables/Document Window/Document.xcstrings
@@ -13535,7 +13535,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "后退"
+            "value" : "返回"
           }
         },
         "zh-HK" : {
@@ -13653,7 +13653,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在文稿历史记录中后退或前进"
+            "value" : "在文稿历史记录中返回或前进"
           }
         },
         "zh-HK" : {


### PR DESCRIPTION
## Summary

- Change the Simplified Chinese Back label from `后退` to `返回`.
- Align the document-history tooltip with the `返回／前进` terminology.

## Rationale

This follows macOS Simplified Chinese navigation terminology and matches the updated Backward/Forward source labels.

## Validation

- Parsed `Document.xcstrings` as JSON.
- Confirmed the navigation pair is `返回` / `前进` and no related `后退` remains.
