### PR TITLE
Add and update translations for zh-HK

### DIFF
--- a/CotEditor/Localizables/Document Window/Accessory Views/FileScopeEditor.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/FileScopeEditor.xcstrings
@@ -55,8 +55,8 @@
         },
         "zh-HK" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "所有"
+            "state" : "translated",
+            "value" : "所有條件"
           }
         }
       }
@@ -115,8 +115,8 @@
         },
         "zh-HK" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "任一"
+            "state" : "translated",
+            "value" : "條件之一"
           }
         }
       }
@@ -175,7 +175,7 @@
         },
         "zh-HK" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "符合下列"
           }
         }
@@ -235,8 +235,8 @@
         },
         "zh-HK" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "條件："
+            "state" : "translated",
+            "value" : "："
           }
         }
       }
@@ -294,8 +294,8 @@
         },
         "zh-HK" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "範圍包括未包括值的規則。"
+            "state" : "translated",
+            "value" : "範圍的規則未包括任何值。"
           }
         }
       }
@@ -353,7 +353,7 @@
         },
         "zh-HK" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "範圍包括無效的常規表示式。"
           }
         }
@@ -980,6 +980,12 @@
             "state" : "translated",
             "value" : "匹配正则表达式"
           }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合常規表示式"
+          }
         }
       }
     },
@@ -1478,6 +1484,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存为命名范围…"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存為已命名的範圍⋯"
           }
         }
       }

--- a/CotEditor/Localizables/Document Window/Document.xcstrings
+++ b/CotEditor/Localizables/Document Window/Document.xcstrings
@@ -684,6 +684,12 @@
             "state" : "translated",
             "value" : "清除文件范围"
           }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除檔案範圍"
+          }
         }
       }
     },
@@ -2794,6 +2800,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑文件范围…"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯檔案範圍⋯"
           }
         }
       }
@@ -7695,6 +7707,12 @@
             "state" : "translated",
             "value" : "管理已保存的范围…"
           }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理儲存的範圍⋯"
+          }
         }
       }
     },
@@ -10952,6 +10970,12 @@
             "state" : "translated",
             "value" : "已保存的范围"
           }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已儲存的範圍"
+          }
         }
       }
     },
@@ -10997,6 +11021,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已保存的范围："
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已儲存的範圍："
           }
         }
       }

--- a/CotEditor/Localizables/Panels/WhatsNew.xcstrings
+++ b/CotEditor/Localizables/Panels/WhatsNew.xcstrings
@@ -264,6 +264,12 @@
             "state" : "translated",
             "value" : "使用“模式”设置，按需为各个语法自定义缩进样式。"
           }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用「模式設定」按需要自訂個別語法的縮排樣式。"
+          }
         }
       }
     },
@@ -316,6 +322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "适配各种语法的缩进"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符合每個語法的縮排"
           }
         }
       }
@@ -374,7 +386,7 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "於macOS 27上，未命名文件會自動從其內容中建議一個草稿名稱。"
+            "value" : "在macOS 27上，未命名的文件會自動從其內容中建議一個草稿名稱。"
           }
         }
       }
@@ -492,7 +504,7 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "直接透過側邊欄搜尋開啟的資料夾中的檔案文字。"
+            "value" : "直接透過側邊欄，在開啟的資料夾的檔案裡搜尋文字。"
           }
         }
       }
@@ -551,7 +563,7 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "於資料夾中尋找"
+            "value" : "在資料夾中尋找"
           }
         }
       }
@@ -669,7 +681,7 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "於資料夾中前後切換瀏覽"
+            "value" : "於資料夾之間前後切換"
           }
         }
       }


### PR DESCRIPTION
p.s. In `zh-HK`:

| English (United States)                | Chinese (Hong Kong) |
| -------------------------------------- | ------------------- |
| Match any of the following conditions: | 符合下列條件之一：  |
| Match all of the following conditions: | 符合下列所有條件：  |

Therefore, in `FileScopeEditor.xcstrings`, “Match [any|all] of the following conditions:” should be translated as:

```
符合下列[條件之一|所有條件]：
^      ^                ^
|      |                |
Match  [any|all]        of the following conditions:
```
I know this may look a bit weird, but that's Apple's official practices. :)

Cheers,
Tiffany
