### PR TITLE
Export default window size settings

### DIFF
--- a/CotEditor/Sources/Application/Defaults/DefaultSettings+Porting.swift
+++ b/CotEditor/Sources/Application/Defaults/DefaultSettings+Porting.swift
@@ -50,6 +50,8 @@ extension DefaultSettings {
         
         // Window
         .windowTabbing,  // = Respect System Setting
+        .windowWidth,
+        .windowHeight,
         .showLineNumbers,
         .showInvisibles,
         .showInvisibleNewLine,

--- a/Tests/Sources/Models/PortableSettingsDocumentTests.swift
+++ b/Tests/Sources/Models/PortableSettingsDocumentTests.swift
@@ -25,6 +25,7 @@
 
 import Foundation
 import Testing
+import Defaults
 import SemanticVersioning
 import SyntaxFormat
 @testable import CotEditor
@@ -45,6 +46,15 @@ import SyntaxFormat
         #expect(fileWrapper.fileWrappers?["Info.json"]?.regularFileContents != nil)
         #expect(syntax.kind == .code)
         #expect(syntax.fileMap.extensions == ["sample"])
+    }
+
+
+    @Test func defaultWindowSizeIsPortable() {
+
+        let keys = DefaultSettings.portableKeys.map(\.rawValue)
+
+        #expect(keys.contains(DefaultKeys.windowWidth.rawValue))
+        #expect(keys.contains(DefaultKeys.windowHeight.rawValue))
     }
     
     


### PR DESCRIPTION
Custom default window width and height values are persisted in the Window settings pane, but `DefaultSettings.portableKeys` omits both keys. Settings archives therefore cannot restore the configured default window size.

Add `windowWidth` and `windowHeight` to the portable defaults registry. Existing automatic sizing behavior remains unchanged.

Test: `xcodebuild test -scheme CotEditor CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= PROVISIONING_PROFILE_SPECIFIER= CODE_SIGN_ENTITLEMENTS_SUFFIX=-AdHoc -skipPackagePluginValidation -only-testing:Tests/PortableSettingsDocumentTests` (2 tests passed).