### PR TITLE
Tweak Turkish translations

### DIFF
--- a/CotEditor/Localizables/Application/Localizable.xcstrings
+++ b/CotEditor/Localizables/Application/Localizable.xcstrings
@@ -1089,7 +1089,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” Ögesini Çoğalt"
+            "value" : "Çoğalt: “%@”"
           }
         },
         "zh-Hans" : {
@@ -2106,7 +2106,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” Ögesini Yeniden Adlandır"
+            "value" : "Yeniden Adlandır: “%@”"
           }
         },
         "zh-Hans" : {
@@ -2445,7 +2445,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” Ögesini Geri Yükle"
+            "value" : "Geri Yükle: “%@”"
           }
         },
         "zh-Hans" : {
@@ -2784,7 +2784,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” Ögesini Finder’da Göster"
+            "value" : "Finder’da Göster: “%@”"
           }
         },
         "zh-Hans" : {
@@ -3690,7 +3690,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” dosyası halihazırda başka bir pencerede açık."
+            "value" : "“%@” dosyası hâlihazırda başka bir pencerede açık."
           }
         },
         "zh-Hans" : {
@@ -4146,7 +4146,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” belgesinde yapılan değişiklikleri kaydetmek ister misiniz?"
+            "value" : "“%@” belgesinde yapılan değişiklikleri kaydetmek istiyor musunuz?"
           }
         },
         "zh-Hans" : {
@@ -8111,7 +8111,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” zaten var. Onu değiştirmek istiyor musunuz?"
+            "value" : "“%@” hâlihazırda var. Onu değiştirmek istiyor musunuz?"
           }
         },
         "zh-Hans" : {
@@ -8225,7 +8225,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aynı adlı bir özelleştirilmiş ayar halihazırda var. Onu değiştirmek geçerli içeriğin üzerine yazacaktır."
+            "value" : "Aynı adlı bir özelleştirilmiş ayar hâlihazırda var. Onu değiştirmek geçerli içeriğin üzerine yazacaktır."
           }
         },
         "zh-Hans" : {
@@ -9130,7 +9130,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” adı halihazırda kullanılıyor."
+            "value" : "“%@” adı hâlihazırda kullanılıyor."
           }
         },
         "zh-Hans" : {
@@ -10036,7 +10036,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aşağıdaki şablonu doldurun ve %1$@’da bir kayıt açın veya %2$@ adresine gönderin. Bu e-postanın içeriğinin “Issues” sayfasında paylaşılacağını not edin. Lütfen içeriği İngilizce veya Japonca yazın."
+            "value" : "Aşağıdaki şablonu doldurun ve %1$@ üzerinde bir kayıt açın veya %2$@ adresine gönderin. Bu e-postanın içeriğinin “Issues” sayfasında paylaşılacağını not edin. Lütfen içeriği İngilizce veya Japonca yazın."
           }
         },
         "zh-Hans" : {
@@ -10715,7 +10715,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Birden çok öge seçili"
+            "value" : "Birden çok öğe seçili"
           }
         },
         "zh-Hans" : {
@@ -10828,7 +10828,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seçili öge yok"
+            "value" : "Seçili öğe yok"
           }
         },
         "zh-Hans" : {
@@ -11502,7 +11502,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hiçbiri"
+            "value" : "Yok"
           }
         },
         "zh-Hans" : {
@@ -13307,7 +13307,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” betiği mevcut değil."
+            "value" : "“%@” betiği yok."
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Application/MainMenu.xcstrings
+++ b/CotEditor/Localizables/Application/MainMenu.xcstrings
@@ -939,7 +939,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Satın Sil"
+            "value" : "Satırı Sil"
           }
         },
         "zh-Hans" : {
@@ -1045,7 +1045,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Satır Yinele"
+            "value" : "Satırı Yinele"
           }
         },
         "zh-Hans" : {
@@ -1152,7 +1152,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@” olarak kodlanıyor"
+            "value" : "“%@” Olarak Kodla"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Document Window/Accessory Views/AdvancedCharacterCount.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/AdvancedCharacterCount.xcstrings
@@ -285,8 +285,8 @@
             "plural" : {
               "one" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "*%lld* character"
+                  "state" : "translated",
+                  "value" : "*%lld* karakter"
                 }
               },
               "other" : {
@@ -534,7 +534,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Belirtilen kodlama ile kodlanmış metnin baytlarını say."
+            "value" : "Belirtilen kodlama ile kodlanmış metnin baytlarını sayın."
           }
         },
         "zh-Hans" : {
@@ -762,7 +762,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unicode’da tanımlandığı üzere sezgisel olarak say. Birden çok Unicode kod noktasından oluşan bir karakter; örneğin Emojiler, bir karakter olarak sayılır."
+            "value" : "Unicode’da tanımlandığı üzere sezgisel olarak sayın. Birden çok Unicode kod noktasından oluşan bir karakter; örneğin Emojiler, bir karakter olarak sayılır."
           }
         },
         "zh-Hans" : {
@@ -990,7 +990,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unicode kod noktalarını say. UTF-32 sayma ile aynıdır."
+            "value" : "Unicode kod noktalarını sayın. UTF-32 sayma ile aynıdır."
           }
         },
         "zh-Hans" : {
@@ -1218,7 +1218,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unicode kod noktalarını say; ancak vekil çifti iki karakter olarak say."
+            "value" : "Unicode kod noktalarını sayın; ancak vekil çifti iki karakter olarak sayın."
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Document Window/Accessory Views/CharacterInspector.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/CharacterInspector.xcstrings
@@ -85,7 +85,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld karakterden oluşan bir harf"
+            "value" : "<%lld karakterden oluşan bir harf>"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Document Window/Accessory Views/FileScopeEditor.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/FileScopeEditor.xcstrings
@@ -1855,7 +1855,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Adlandırılmış Kapsam Olarak Kaydet…"
+            "value" : "Adlı Kapsam Olarak Kaydet…"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Document Window/Accessory Views/LiveTextInsertion.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/LiveTextInsertion.xcstrings
@@ -297,7 +297,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Metin saptanmadı"
+            "value" : "Saptanan metin yok"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Document Window/Accessory Views/PatternSort.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/PatternSort.xcstrings
@@ -617,7 +617,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Büyük-Küçük Harf Fark Etmez"
+            "value" : "BÜYÜK/küçük harf duyarsız"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Document Window/Accessory Views/PrintAccessory.xcstrings
+++ b/CotEditor/Localizables/Document Window/Accessory Views/PrintAccessory.xcstrings
@@ -531,7 +531,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Siyah - Beyaz"
+            "value" : "Siyah–Beyaz"
           }
         },
         "zh-Hans" : {
@@ -1838,7 +1838,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hiçbiri"
+            "value" : "Yok"
           }
         },
         "zh-Hans" : {
@@ -2177,7 +2177,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizim Adı"
+            "value" : "Sözdizimi Adı"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Document Window/Document.xcstrings
+++ b/CotEditor/Localizables/Document Window/Document.xcstrings
@@ -6204,7 +6204,7 @@
               "one" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "Bir uyumsuz karakter bulundu."
+                  "value" : "1 uyumsuz karakter bulundu."
                 }
               },
               "other" : {
@@ -6779,7 +6779,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Görüntü DPI’sı"
+            "value" : "Görüntü DPI’si"
           }
         },
         "zh-Hans" : {
@@ -18910,7 +18910,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizimi değiştir"
+            "value" : "Sözdizimini değiştir"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Panels/SettingsPorting.xcstrings
+++ b/CotEditor/Localizables/Panels/SettingsPorting.xcstrings
@@ -285,13 +285,13 @@
               "one" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "%lld özel sözdizim"
+                  "value" : "%lld özel sözdizimi"
                 }
               },
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "%lld özel sözdizim"
+                  "value" : "%lld özel sözdizimi"
                 }
               }
             }
@@ -1966,7 +1966,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ayarları İçe Aktar"
+            "value" : "Ayarlar İçe Aktar"
           }
         },
         "zh-Hans" : {
@@ -2631,7 +2631,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizimler"
+            "value" : "Sözdizimleri"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Other Views/SyntaxMappingConflict.xcstrings
+++ b/CotEditor/Localizables/Settings/Other Views/SyntaxMappingConflict.xcstrings
@@ -85,7 +85,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yinelenmiş Sözdizimler"
+            "value" : "Yinelenmiş Sözdizimleri"
           }
         },
         "zh-Hans" : {
@@ -513,7 +513,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizim Eşlemleme Çakışmaları"
+            "value" : "Sözdizimi Eşlemleme Çakışmaları"
           }
         },
         "zh-Hans" : {
@@ -619,7 +619,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aşağıdaki dosya eşlemleme kuralları birden çok sözdizimde kayıtlıdır. CotEditor, kendiliğinden ilk sözdizimi kullanır. Çakışmaları çözmek için her bir sözdizim tanımını düzenleyin."
+            "value" : "Aşağıdaki dosya eşlemleme kuralları birden çok sözdiziminde kayıtlıdır. CotEditor, kendiliğinden ilk sözdizimini kullanır. Çakışmaları çözmek için her bir sözdizimi tanımını düzenleyin."
           }
         },
         "zh-Hans" : {
@@ -726,7 +726,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kullanılan Sözdizim"
+            "value" : "Kullanılan Sözdizimi"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Other Views/ThemeEditor.xcstrings
+++ b/CotEditor/Localizables/Settings/Other Views/ThemeEditor.xcstrings
@@ -1357,7 +1357,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizim"
+            "value" : "Sözdizimi"
           }
         },
         "zh-Hans" : {
@@ -1681,7 +1681,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tema editörü"
+            "value" : "Tema Düzenleyicisi"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Panes/AppearanceSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/AppearanceSettings.xcstrings
@@ -1273,7 +1273,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sabit genişlikli yazıtipi:"
+            "value" : "Sabit genişlikli font:"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Panes/FormatSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/FormatSettings.xcstrings
@@ -84,7 +84,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kullanılabilir sözdizimler:"
+            "value" : "Kullanılabilir sözdizimleri:"
           }
         },
         "zh-Hans" : {
@@ -290,7 +290,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Özelleştirilmiş sözdizimler"
+            "value" : "Özelleştirilmiş sözdizimleri"
           }
         },
         "zh-Hans" : {
@@ -502,7 +502,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Öntanımlı sözdizim:"
+            "value" : "Öntanımlı sözdizimi:"
           }
         },
         "zh-Hans" : {
@@ -1257,7 +1257,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu sözdizim yok"
+            "value" : "Bu sözdizimi yok"
           }
         },
         "zh-Hans" : {
@@ -1369,7 +1369,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu sözdizim özelleştirilmiş."
+            "value" : "Bu sözdizimi özelleştirilmiş."
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Panes/GeneralSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/GeneralSettings.xcstrings
@@ -2162,7 +2162,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hiçbir Şey Yapma"
+            "value" : "Bir Şey Yapma"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Panes/ModeSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/ModeSettings.xcstrings
@@ -2226,7 +2226,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizim"
+            "value" : "Sözdizimi"
           }
         },
         "zh-Hans" : {
@@ -2440,7 +2440,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu sözdizim yok"
+            "value" : "Bu sözdizimi yok"
           }
         },
         "zh-Hans" : {
@@ -2652,7 +2652,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizimde tanımlı sözcükler"
+            "value" : "Sözdiziminde tanımlı sözcükler"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Panes/SnippetsSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/SnippetsSettings.xcstrings
@@ -1272,7 +1272,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizim"
+            "value" : "Sözdizimi"
           }
         },
         "zh-Hans" : {
@@ -1379,7 +1379,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu dosya bırakma ayarının etkinleştirildiği sözdizim"
+            "value" : "Bu dosya bırakma ayarının etkinleştirildiği sözdizimi"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Panes/WindowSettings.xcstrings
+++ b/CotEditor/Localizables/Settings/Panes/WindowSettings.xcstrings
@@ -981,7 +981,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Girintileme Kılavuzları"
+            "value" : "Girintileme kılavuzları"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/Settings.xcstrings
+++ b/CotEditor/Localizables/Settings/Settings.xcstrings
@@ -317,7 +317,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Düzenle"
+            "value" : "Düzen"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Settings/SyntaxEditor.xcstrings
+++ b/CotEditor/Localizables/Settings/SyntaxEditor.xcstrings
@@ -1504,7 +1504,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uygulama ile gelen sözdizimler yeniden adlandırılamaz."
+            "value" : "Uygulama ile gelen sözdizimleri yeniden adlandırılamaz."
           }
         },
         "zh-Hans" : {
@@ -1611,7 +1611,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Karakter sınırlayıcılar:"
+            "value" : "Karakter sınırlayıcıları:"
           }
         },
         "zh-Hans" : {
@@ -3430,7 +3430,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Belirtilmemişse sözdizim tamamlama sözcükleri vurgulama ayarları tabanlı olarak üretilir."
+            "value" : "Belirtilmemişse sözdizimi tamamlama sözcükleri vurgulama ayarları tabanlı olarak üretilir."
           }
         },
         "zh-Hans" : {
@@ -5037,7 +5037,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hiçbiri"
+            "value" : "Yok"
           }
         },
         "zh-Hans" : {
@@ -5572,7 +5572,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dizi sınırlayıcılar:"
+            "value" : "Dizi sınırlayıcıları:"
           }
         },
         "zh-Hans" : {
@@ -5678,7 +5678,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sözdizim Adı"
+            "value" : "Sözdizimi Adı"
           }
         },
         "zh-Hans" : {
@@ -6584,7 +6584,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu dil, sözdizim analizi için tree-sitter adı verilen yapı tabanlı, genel amaçlı bir ayrıştırıcı kullanır.\nÇıkarma kuralları uygulama tarafından yönetildiğinden, bunları özelleştiremezsiniz."
+            "value" : "Bu dil, sözdizimi analizi için tree-sitter adı verilen yapı tabanlı, genel amaçlı bir ayrıştırıcı kullanır.\nÇıkarma kuralları uygulama tarafından yönetildiğinden, bunları özelleştiremezsiniz."
           }
         },
         "zh-Hans" : {
@@ -6796,7 +6796,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Burada tanımlanan ayırıcılar, sözdizim vurgulaması için de kullanılır."
+            "value" : "Burada tanımlanan ayırıcılar, sözdizimi vurgulaması için de kullanılır."
           }
         },
         "zh-Hans" : {
@@ -6903,7 +6903,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yorumlayıcılar, belgedeki `#!` üstbilgisinden sözdizimi belirlemek için kullanılır."
+            "value" : "Yorumlayıcılar, belgedeki `#!` üstbilgisinden sözdizimini belirlemek için kullanılır."
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Text Finder/MultipleReplace.xcstrings
+++ b/CotEditor/Localizables/Text Finder/MultipleReplace.xcstrings
@@ -85,7 +85,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kural Sil"
+            "value" : "Kuralı Sil"
           }
         },
         "zh-Hans" : {
@@ -192,7 +192,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kural Düzenle"
+            "value" : "Kuralı Düzenle"
           }
         },
         "zh-Hans" : {
@@ -520,7 +520,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kural Taşı"
+            "value" : "Kuralı Taşı"
           }
         },
         "zh-Hans" : {

--- a/CotEditor/Localizables/Text Finder/TextFind.xcstrings
+++ b/CotEditor/Localizables/Text Finder/TextFind.xcstrings
@@ -742,7 +742,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Upřesňující možnosti hledání"
+            "value" : "Gelişmiş Bulma Ayarları"
           }
         },
         "zh-Hans" : {
@@ -956,7 +956,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Büyük-Küçük Harfe Duyarlı"
+            "value" : "BÜYÜK/küçük Harf Duyarlı"
           }
         },
         "zh-Hans" : {
@@ -1491,7 +1491,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bulma sonucunu kapat."
+            "value" : "Bulma sonucunu kapatın."
           }
         },
         "zh-Hans" : {
@@ -1919,7 +1919,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vyhledat a vypsat všechny shody."
+            "value" : "Tüm eşleşmeleri bulun ve listeleyin."
           }
         },
         "zh-Hans" : {
@@ -2133,7 +2133,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bir sonraki eşleşmeyi bul."
+            "value" : "Bir sonraki eşleşmeyi bulun."
           }
         },
         "zh-Hans" : {
@@ -2347,7 +2347,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bir önceki eşleşmeyi bul."
+            "value" : "Bir önceki eşleşmeyi bulun."
           }
         },
         "zh-Hans" : {
@@ -6347,7 +6347,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Büyük-Küçük Harf Fark Etmez"
+            "value" : "BÜYÜK/küçük Harf Duyarsız"
           }
         },
         "zh-Hans" : {
@@ -9044,7 +9044,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vyberte rozsah vyhledávání v dokumentu nebo zakažte možnost „ve výběru“."
+            "value" : "Belgedeki arama kapsamını seçin veya “seçimde” seçeneğinin işaretini kaldırın."
           }
         },
         "zh-Hans" : {


### PR DESCRIPTION
Includes some fixes to be more macOS like and obvious errors missed in previous iterations. Also translated some Polish text that made it into Turkish strings.