### PR TITLE
Add Log syntax

### DIFF
--- a/CotEditor/Resources/Syntaxes/Log.cotsyntax/Info.json
+++ b/CotEditor/Resources/Syntaxes/Log.cotsyntax/Info.json
@@ -1,0 +1,15 @@
+{
+  "fileMap" : {
+    "extensions" : [
+      "log"
+    ]
+  },
+  "kind" : "code",
+  "metadata" : {
+    "author" : "roove",
+    "distributionURL" : "https://coteditor.com",
+    "lastModified" : "2026-09-06",
+    "license" : "Same as CotEditor",
+    "version" : "1.1.0"
+  }
+}

--- a/CotEditor/Resources/Syntaxes/Log.cotsyntax/Regex/Highlights.json
+++ b/CotEditor/Resources/Syntaxes/Log.cotsyntax/Regex/Highlights.json
@@ -1,0 +1,103 @@
+{
+  "attributes" : [
+    {
+      "begin" : "\\b[\\w$.]+(?:Exception|Error)\\b",
+      "regularExpression" : true
+    }
+  ],
+  "characters" : [
+    {
+      "begin" : "\\b(INFO|Info|INFORMATION|Information|INF|NOTICE|Notice)\\b",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "(?i)\\b(info(rmation)?|notice)\\s*:",
+      "regularExpression" : true
+    }
+  ],
+  "comments" : [
+    {
+      "begin" : "\\b(DEBUG|Debug|DBG|TRACE|Trace|VERBOSE|Verbose|VRB)\\b",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "(?i)\\b(debug|trace|verbose)\\s*:",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "\\b\\d{4}[-/.]\\d{2}[-/.]\\d{2}(?=T|\\b)([T ][\\d:,.+Z-]+)?",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "\\b\\d{1,2}[-/.]\\d{1,2}[-/.]\\d{4}\\b",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "\\b\\d{1,2}:\\d{2}(:\\d{2}([.,]\\d{1,})?)?(Z|[+-]\\d{1,2}:?\\d{2})?\\b",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "^\\s+at\\s",
+      "end" : "$",
+      "regularExpression" : true
+    }
+  ],
+  "numbers" : [
+    {
+      "begin" : "\\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\b",
+      "ignoreCase" : true,
+      "regularExpression" : true
+    },
+    {
+      "begin" : "\\b(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}\\b",
+      "ignoreCase" : true,
+      "regularExpression" : true
+    },
+    {
+      "begin" : "[a-z][a-z0-9+.-]*://\\S+",
+      "ignoreCase" : true,
+      "regularExpression" : true
+    },
+    {
+      "begin" : "\\b(?:true|false|null|nil|none)\\b",
+      "ignoreCase" : true,
+      "regularExpression" : true
+    }
+  ],
+  "strings" : [
+    {
+      "begin" : "(?<![\\w'])\"[^\"\\r\\n]+\"(?![\\w'])",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "(?<![\\w'])'[^'\\r\\n]+'(?![\\w'])",
+      "regularExpression" : true
+    }
+  ],
+  "types" : [
+    {
+      "begin" : "\\b(WARN|Warn|WARNING|Warning|WRN)\\b",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "(?i)\\bwarn(ing)?\\s*:",
+      "regularExpression" : true
+    }
+  ],
+  "values" : [
+    {
+      "begin" : "\\b(ALERT|CRITICAL|EMERG(ENCY)?|ERROR|Error|FATAL|Fatal|SEVERE|PANIC|Panic|FAIL(ED|URE)?)\\b",
+      "regularExpression" : true
+    },
+    {
+      "begin" : "(?i)\\b(error|fatal|severe|panic)\\s*:",
+      "regularExpression" : true
+    }
+  ],
+  "variables" : [
+    {
+      "begin" : "(?<![:/\\w])/[\\w.\\-]*[a-zA-Z][\\w.\\-]*(?:/[\\w.\\-]+)+",
+      "regularExpression" : true
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This PR adds a new built-in syntax definition **Log** for `.log` files, which currently fall back to Plain Text with no highlighting.

- `CotEditor/Resources/Syntaxes/Log.cotsyntax/` — pure regex-based definition (`Info.json` + `Regex/Highlights.json`, no `Outlines.json`/`Edit.json`)
- `SyntaxMap.json` is intentionally untouched, following CONTRIBUTING.md (regenerated by the build phase; verified with a real `SyntaxMapBuilder` run)

## Design

The rules follow the conventions of VS Code's built-in Log language (originating from [emilast/vscode-logfile-highlighter](https://github.com/emilast/vscode-logfile-highlighter)), adapted to CotEditor's 10 fixed syntax types:

| Element | SyntaxType |
|---|---|
| `ERROR`/`FATAL`/`CRITICAL`/`ALERT`/`EMERG`/`SEVERE`/`PANIC`/`FAIL`… | `values` |
| `WARN`/`WRN` | `types` |
| `INFO`/`NOTICE`/`INF` | `characters` |
| `DEBUG`/`TRACE`/`VERBOSE` | `comments` |
| Timestamps (ISO / short date / bare time / bracketed) and Java-style stack trace lines (^`at`) | `comments` (muted) |
| Quoted strings | `strings` |
| URLs / GUIDs / MAC addresses / `true`/`false`/`null` | `numbers` |
| Qualified exception class names | `attributes` |
| Absolute paths | `variables` |

False-positive guards are taken from the VS Code grammar: case-sensitive level spellings (lowercase only highlighted in `error:` colon form), `(?=T|\b)` date lookahead, apostrophe-safe quoted strings, and URL-internal segments excluded from the path rule.

## Notes

- CONTRIBUTING.md asks for an issue discussion before PRs for new built-in syntaxes — happy to move the discussion to an issue if preferred; this PR is meant as a concrete starting point. My guess is that log files are common enough (VS Code ships a built-in log grammar) that a built-in definition is warranted, but the maintainers may of course decide otherwise.
- License is "Same as CotEditor"; version 1.1.0.