### PR TITLE
Add Spin and PASM syntax styles for Propeller 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Improvements
 
+- Add Spin and PASM syntaxes for Parallax Propeller 1 (P8X32A).
 - [beta] Improve the performance of the folder find pane.
 - [beta] Limit folder find results to 5,000 matches per file and 500,000 matches in total, and indicate when the limit is reached.
 - [beta][dev] Update the build environment to Xcode 27 RC.

--- a/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Completion.json
+++ b/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Completion.json
@@ -1,0 +1,658 @@
+[
+  {
+    "text": "ABS",
+    "type": "commands"
+  },
+  {
+    "text": "ABSNEG",
+    "type": "commands"
+  },
+  {
+    "text": "ADD",
+    "type": "commands"
+  },
+  {
+    "text": "ADDABS",
+    "type": "commands"
+  },
+  {
+    "text": "ADDS",
+    "type": "commands"
+  },
+  {
+    "text": "ADDSX",
+    "type": "commands"
+  },
+  {
+    "text": "ADDX",
+    "type": "commands"
+  },
+  {
+    "text": "AND",
+    "type": "commands"
+  },
+  {
+    "text": "ANDN",
+    "type": "commands"
+  },
+  {
+    "text": "CALL",
+    "type": "commands"
+  },
+  {
+    "text": "CLKSET",
+    "type": "commands"
+  },
+  {
+    "text": "CMP",
+    "type": "commands"
+  },
+  {
+    "text": "CMPS",
+    "type": "commands"
+  },
+  {
+    "text": "CMPSUB",
+    "type": "commands"
+  },
+  {
+    "text": "CMPSX",
+    "type": "commands"
+  },
+  {
+    "text": "CMPX",
+    "type": "commands"
+  },
+  {
+    "text": "COGID",
+    "type": "commands"
+  },
+  {
+    "text": "COGINIT",
+    "type": "commands"
+  },
+  {
+    "text": "COGSTOP",
+    "type": "commands"
+  },
+  {
+    "text": "DJNZ",
+    "type": "commands"
+  },
+  {
+    "text": "HUBOP",
+    "type": "commands"
+  },
+  {
+    "text": "JMP",
+    "type": "commands"
+  },
+  {
+    "text": "JMPRET",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKCLR",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKNEW",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKRET",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKSET",
+    "type": "commands"
+  },
+  {
+    "text": "MAX",
+    "type": "commands"
+  },
+  {
+    "text": "MAXS",
+    "type": "commands"
+  },
+  {
+    "text": "MIN",
+    "type": "commands"
+  },
+  {
+    "text": "MINS",
+    "type": "commands"
+  },
+  {
+    "text": "MOV",
+    "type": "commands"
+  },
+  {
+    "text": "MOVD",
+    "type": "commands"
+  },
+  {
+    "text": "MOVI",
+    "type": "commands"
+  },
+  {
+    "text": "MOVS",
+    "type": "commands"
+  },
+  {
+    "text": "MUXC",
+    "type": "commands"
+  },
+  {
+    "text": "MUXNC",
+    "type": "commands"
+  },
+  {
+    "text": "MUXNZ",
+    "type": "commands"
+  },
+  {
+    "text": "MUXZ",
+    "type": "commands"
+  },
+  {
+    "text": "NEG",
+    "type": "commands"
+  },
+  {
+    "text": "NEGC",
+    "type": "commands"
+  },
+  {
+    "text": "NEGNC",
+    "type": "commands"
+  },
+  {
+    "text": "NEGNZ",
+    "type": "commands"
+  },
+  {
+    "text": "NEGZ",
+    "type": "commands"
+  },
+  {
+    "text": "NOP",
+    "type": "commands"
+  },
+  {
+    "text": "OR",
+    "type": "commands"
+  },
+  {
+    "text": "RCL",
+    "type": "commands"
+  },
+  {
+    "text": "RCR",
+    "type": "commands"
+  },
+  {
+    "text": "RDBYTE",
+    "type": "commands"
+  },
+  {
+    "text": "RDLONG",
+    "type": "commands"
+  },
+  {
+    "text": "RDWORD",
+    "type": "commands"
+  },
+  {
+    "text": "RET",
+    "type": "commands"
+  },
+  {
+    "text": "REV",
+    "type": "commands"
+  },
+  {
+    "text": "ROL",
+    "type": "commands"
+  },
+  {
+    "text": "ROR",
+    "type": "commands"
+  },
+  {
+    "text": "SAR",
+    "type": "commands"
+  },
+  {
+    "text": "SHL",
+    "type": "commands"
+  },
+  {
+    "text": "SHR",
+    "type": "commands"
+  },
+  {
+    "text": "SUB",
+    "type": "commands"
+  },
+  {
+    "text": "SUBABS",
+    "type": "commands"
+  },
+  {
+    "text": "SUBS",
+    "type": "commands"
+  },
+  {
+    "text": "SUBSX",
+    "type": "commands"
+  },
+  {
+    "text": "SUBX",
+    "type": "commands"
+  },
+  {
+    "text": "SUMC",
+    "type": "commands"
+  },
+  {
+    "text": "SUMNC",
+    "type": "commands"
+  },
+  {
+    "text": "SUMNZ",
+    "type": "commands"
+  },
+  {
+    "text": "SUMZ",
+    "type": "commands"
+  },
+  {
+    "text": "TEST",
+    "type": "commands"
+  },
+  {
+    "text": "TESTN",
+    "type": "commands"
+  },
+  {
+    "text": "TJNZ",
+    "type": "commands"
+  },
+  {
+    "text": "TJZ",
+    "type": "commands"
+  },
+  {
+    "text": "WAITCNT",
+    "type": "commands"
+  },
+  {
+    "text": "WAITPEQ",
+    "type": "commands"
+  },
+  {
+    "text": "WAITPNE",
+    "type": "commands"
+  },
+  {
+    "text": "WAITVID",
+    "type": "commands"
+  },
+  {
+    "text": "WRBYTE",
+    "type": "commands"
+  },
+  {
+    "text": "WRLONG",
+    "type": "commands"
+  },
+  {
+    "text": "WRWORD",
+    "type": "commands"
+  },
+  {
+    "text": "XOR",
+    "type": "commands"
+  },
+  {
+    "text": "IF_ALWAYS",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NEVER",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_E",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NE",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_A",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_B",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_AE",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_BE",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_EQ_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_EQ_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_NE_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_NE_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_AND_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_AND_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_AND_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_AND_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_AND_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_AND_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_AND_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_AND_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_OR_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_OR_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_OR_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_OR_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_OR_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_OR_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_OR_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_OR_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "WC",
+    "type": "attributes"
+  },
+  {
+    "text": "WZ",
+    "type": "attributes"
+  },
+  {
+    "text": "WR",
+    "type": "attributes"
+  },
+  {
+    "text": "NR",
+    "type": "attributes"
+  },
+  {
+    "text": "ANDC",
+    "type": "attributes"
+  },
+  {
+    "text": "ANDZ",
+    "type": "attributes"
+  },
+  {
+    "text": "ORC",
+    "type": "attributes"
+  },
+  {
+    "text": "ORZ",
+    "type": "attributes"
+  },
+  {
+    "text": "XORC",
+    "type": "attributes"
+  },
+  {
+    "text": "XORZ",
+    "type": "attributes"
+  },
+  {
+    "text": "ORG",
+    "type": "keywords"
+  },
+  {
+    "text": "FIT",
+    "type": "keywords"
+  },
+  {
+    "text": "RES",
+    "type": "keywords"
+  },
+  {
+    "text": "BYTE",
+    "type": "types"
+  },
+  {
+    "text": "WORD",
+    "type": "types"
+  },
+  {
+    "text": "LONG",
+    "type": "types"
+  },
+  {
+    "text": "INA",
+    "type": "variables"
+  },
+  {
+    "text": "INB",
+    "type": "variables"
+  },
+  {
+    "text": "OUTA",
+    "type": "variables"
+  },
+  {
+    "text": "OUTB",
+    "type": "variables"
+  },
+  {
+    "text": "DIRA",
+    "type": "variables"
+  },
+  {
+    "text": "DIRB",
+    "type": "variables"
+  },
+  {
+    "text": "CNT",
+    "type": "variables"
+  },
+  {
+    "text": "CTRA",
+    "type": "variables"
+  },
+  {
+    "text": "CTRB",
+    "type": "variables"
+  },
+  {
+    "text": "FRQA",
+    "type": "variables"
+  },
+  {
+    "text": "FRQB",
+    "type": "variables"
+  },
+  {
+    "text": "PHSA",
+    "type": "variables"
+  },
+  {
+    "text": "PHSB",
+    "type": "variables"
+  },
+  {
+    "text": "VCFG",
+    "type": "variables"
+  },
+  {
+    "text": "VSCL",
+    "type": "variables"
+  },
+  {
+    "text": "PAR",
+    "type": "variables"
+  },
+  {
+    "text": "SPR",
+    "type": "variables"
+  },
+  {
+    "text": "RESULT",
+    "type": "variables"
+  },
+  {
+    "text": "TRUE",
+    "type": "values"
+  },
+  {
+    "text": "FALSE",
+    "type": "values"
+  },
+  {
+    "text": "POSX",
+    "type": "values"
+  },
+  {
+    "text": "NEGX",
+    "type": "values"
+  },
+  {
+    "text": "PI",
+    "type": "values"
+  },
+  {
+    "text": "XTAL1",
+    "type": "values"
+  },
+  {
+    "text": "XTAL2",
+    "type": "values"
+  },
+  {
+    "text": "XTAL3",
+    "type": "values"
+  },
+  {
+    "text": "XINPUT",
+    "type": "values"
+  },
+  {
+    "text": "RCSLOW",
+    "type": "values"
+  },
+  {
+    "text": "RCFAST",
+    "type": "values"
+  },
+  {
+    "text": "PLL1X",
+    "type": "values"
+  },
+  {
+    "text": "PLL2X",
+    "type": "values"
+  },
+  {
+    "text": "PLL4X",
+    "type": "values"
+  },
+  {
+    "text": "PLL8X",
+    "type": "values"
+  },
+  {
+    "text": "PLL16X",
+    "type": "values"
+  },
+  {
+    "text": "_clkmode",
+    "type": "values"
+  },
+  {
+    "text": "_xinfreq",
+    "type": "values"
+  },
+  {
+    "text": "_clkfreq",
+    "type": "values"
+  }
+]

--- a/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Edit.json
+++ b/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Edit.json
@@ -1,0 +1,22 @@
+{
+  "comment": {
+    "blocks": [
+      {
+        "begin": "{",
+        "end": "}",
+        "isNestable": true
+      }
+    ],
+    "inlines": [
+      {
+        "begin": "'"
+      }
+    ]
+  },
+  "stringDelimiters": [
+    {
+      "begin": "\"",
+      "end": "\""
+    }
+  ]
+}

--- a/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Info.json
+++ b/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Info.json
@@ -1,0 +1,16 @@
+{
+  "fileMap": {
+    "extensions": [
+      "pasm"
+    ]
+  },
+  "kind": "code",
+  "metadata": {
+    "author": "Phillip Stevens",
+    "description": "Parallax Propeller 1 (P8X32A) assembly (PASM). Not PASM2. Mnemonics, conditions, and effects from the P1 quick reference.",
+    "distributionURL": "https://coteditor.com",
+    "lastModified": "2026-09-10",
+    "license": "Same as CotEditor",
+    "version": "1.0.0"
+  }
+}

--- a/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Regex/Highlights.json
+++ b/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Regex/Highlights.json
@@ -1,0 +1,728 @@
+{
+  "keywords": [
+    {
+      "begin": "ORG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FIT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RES",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CON",
+      "ignoreCase": true
+    },
+    {
+      "begin": "VAR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OBJ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PUB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PRI",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DAT",
+      "ignoreCase": true
+    }
+  ],
+  "commands": [
+    {
+      "begin": "ABS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ABSNEG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDABS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "AND",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ANDN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CALL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CLKSET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPSUB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "COGID",
+      "ignoreCase": true
+    },
+    {
+      "begin": "COGINIT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "COGSTOP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DJNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "HUBOP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "JMP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "JMPRET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKCLR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKNEW",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKRET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKSET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MAX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MAXS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MIN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MINS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOV",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOVD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOVI",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOVS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXNC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGNC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NOP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RDBYTE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RDLONG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RDWORD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "REV",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ROL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ROR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SAR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SHL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SHR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBABS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMNC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TEST",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TESTN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TJNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TJZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITCNT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITPEQ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITPNE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITVID",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WRBYTE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WRLONG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WRWORD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XOR",
+      "ignoreCase": true
+    }
+  ],
+  "types": [
+    {
+      "begin": "BYTE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WORD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LONG",
+      "ignoreCase": true
+    }
+  ],
+  "attributes": [
+    {
+      "begin": "IF_ALWAYS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NEVER",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_E",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_A",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_B",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_AE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_BE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_EQ_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_EQ_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_NE_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_NE_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_AND_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_AND_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_AND_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_AND_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_AND_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_AND_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_AND_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_AND_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_OR_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_OR_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_OR_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_OR_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_OR_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_OR_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_OR_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_OR_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ANDC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ANDZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ORC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ORZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XORC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XORZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": ":[A-Za-z_][A-Za-z0-9_]*",
+      "regularExpression": true,
+      "description": "local label"
+    }
+  ],
+  "variables": [
+    {
+      "begin": "INA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "INB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OUTA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OUTB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DIRA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DIRB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CNT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CTRA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CTRB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FRQA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FRQB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PHSA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PHSB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "VCFG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "VSCL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PAR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SPR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RESULT",
+      "ignoreCase": true
+    }
+  ],
+  "values": [
+    {
+      "begin": "TRUE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FALSE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "POSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PI",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XTAL1",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XTAL2",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XTAL3",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XINPUT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCSLOW",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCFAST",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL1X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL2X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL4X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL8X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL16X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "_clkmode",
+      "ignoreCase": true
+    },
+    {
+      "begin": "_xinfreq",
+      "ignoreCase": true
+    },
+    {
+      "begin": "_clkfreq",
+      "ignoreCase": true
+    }
+  ],
+  "numbers": [
+    {
+      "begin": "%%[0-3][0-3_]*",
+      "regularExpression": true,
+      "description": "quaternary"
+    },
+    {
+      "begin": "%[01][01_]*",
+      "regularExpression": true,
+      "description": "binary"
+    },
+    {
+      "begin": "\\$[0-9A-Fa-f][0-9A-Fa-f_]*",
+      "regularExpression": true,
+      "description": "hex"
+    },
+    {
+      "begin": "\\b[0-9][0-9_]*\\b",
+      "regularExpression": true,
+      "description": "decimal"
+    }
+  ],
+  "characters": [
+    {
+      "begin": "#\"[^\"]\"",
+      "regularExpression": true,
+      "description": "character literal"
+    }
+  ]
+}

--- a/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Regex/Outlines.json
+++ b/CotEditor/Resources/Syntaxes/PASM.cotsyntax/Regex/Outlines.json
@@ -1,0 +1,22 @@
+[
+  {
+    "description": "ORG",
+    "ignoreCase": true,
+    "kind": "container",
+    "pattern": "^[\\t ]*org\\b.*",
+    "template": "$0"
+  },
+  {
+    "description": "FIT",
+    "ignoreCase": true,
+    "kind": "container",
+    "pattern": "^[\\t ]*fit\\b.*",
+    "template": "$0"
+  },
+  {
+    "description": "Label",
+    "kind": "function",
+    "pattern": "^([A-Za-z_][A-Za-z0-9_]*)\\b",
+    "template": "$1"
+  }
+]

--- a/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Completion.json
+++ b/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Completion.json
@@ -1,0 +1,842 @@
+[
+  {
+    "text": "CON",
+    "type": "keywords"
+  },
+  {
+    "text": "VAR",
+    "type": "keywords"
+  },
+  {
+    "text": "OBJ",
+    "type": "keywords"
+  },
+  {
+    "text": "PUB",
+    "type": "keywords"
+  },
+  {
+    "text": "PRI",
+    "type": "keywords"
+  },
+  {
+    "text": "DAT",
+    "type": "keywords"
+  },
+  {
+    "text": "IF",
+    "type": "keywords"
+  },
+  {
+    "text": "IFNOT",
+    "type": "keywords"
+  },
+  {
+    "text": "ELSEIF",
+    "type": "keywords"
+  },
+  {
+    "text": "ELSEIFNOT",
+    "type": "keywords"
+  },
+  {
+    "text": "ELSE",
+    "type": "keywords"
+  },
+  {
+    "text": "CASE",
+    "type": "keywords"
+  },
+  {
+    "text": "OTHER",
+    "type": "keywords"
+  },
+  {
+    "text": "REPEAT",
+    "type": "keywords"
+  },
+  {
+    "text": "WHILE",
+    "type": "keywords"
+  },
+  {
+    "text": "UNTIL",
+    "type": "keywords"
+  },
+  {
+    "text": "FROM",
+    "type": "keywords"
+  },
+  {
+    "text": "TO",
+    "type": "keywords"
+  },
+  {
+    "text": "STEP",
+    "type": "keywords"
+  },
+  {
+    "text": "NEXT",
+    "type": "keywords"
+  },
+  {
+    "text": "QUIT",
+    "type": "keywords"
+  },
+  {
+    "text": "RETURN",
+    "type": "keywords"
+  },
+  {
+    "text": "ABORT",
+    "type": "keywords"
+  },
+  {
+    "text": "AND",
+    "type": "commands"
+  },
+  {
+    "text": "OR",
+    "type": "commands"
+  },
+  {
+    "text": "NOT",
+    "type": "keywords"
+  },
+  {
+    "text": "BYTE",
+    "type": "types"
+  },
+  {
+    "text": "WORD",
+    "type": "types"
+  },
+  {
+    "text": "LONG",
+    "type": "types"
+  },
+  {
+    "text": "STRSIZE",
+    "type": "commands"
+  },
+  {
+    "text": "STRCOMP",
+    "type": "commands"
+  },
+  {
+    "text": "STRING",
+    "type": "commands"
+  },
+  {
+    "text": "LOOKUP",
+    "type": "commands"
+  },
+  {
+    "text": "LOOKUPZ",
+    "type": "commands"
+  },
+  {
+    "text": "LOOKDOWN",
+    "type": "commands"
+  },
+  {
+    "text": "LOOKDOWNZ",
+    "type": "commands"
+  },
+  {
+    "text": "CONSTANT",
+    "type": "commands"
+  },
+  {
+    "text": "FLOAT",
+    "type": "commands"
+  },
+  {
+    "text": "ROUND",
+    "type": "commands"
+  },
+  {
+    "text": "TRUNC",
+    "type": "commands"
+  },
+  {
+    "text": "BYTEFILL",
+    "type": "commands"
+  },
+  {
+    "text": "WORDFILL",
+    "type": "commands"
+  },
+  {
+    "text": "LONGFILL",
+    "type": "commands"
+  },
+  {
+    "text": "BYTEMOVE",
+    "type": "commands"
+  },
+  {
+    "text": "WORDMOVE",
+    "type": "commands"
+  },
+  {
+    "text": "LONGMOVE",
+    "type": "commands"
+  },
+  {
+    "text": "COGNEW",
+    "type": "commands"
+  },
+  {
+    "text": "COGINIT",
+    "type": "commands"
+  },
+  {
+    "text": "COGSTOP",
+    "type": "commands"
+  },
+  {
+    "text": "COGID",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKNEW",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKRET",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKSET",
+    "type": "commands"
+  },
+  {
+    "text": "LOCKCLR",
+    "type": "commands"
+  },
+  {
+    "text": "WAITCNT",
+    "type": "commands"
+  },
+  {
+    "text": "WAITPEQ",
+    "type": "commands"
+  },
+  {
+    "text": "WAITPNE",
+    "type": "commands"
+  },
+  {
+    "text": "WAITVID",
+    "type": "commands"
+  },
+  {
+    "text": "CLKSET",
+    "type": "commands"
+  },
+  {
+    "text": "REBOOT",
+    "type": "commands"
+  },
+  {
+    "text": "CHIPVER",
+    "type": "commands"
+  },
+  {
+    "text": "CLKFREQ",
+    "type": "commands"
+  },
+  {
+    "text": "CLKMODE",
+    "type": "commands"
+  },
+  {
+    "text": "INA",
+    "type": "variables"
+  },
+  {
+    "text": "INB",
+    "type": "variables"
+  },
+  {
+    "text": "OUTA",
+    "type": "variables"
+  },
+  {
+    "text": "OUTB",
+    "type": "variables"
+  },
+  {
+    "text": "DIRA",
+    "type": "variables"
+  },
+  {
+    "text": "DIRB",
+    "type": "variables"
+  },
+  {
+    "text": "CNT",
+    "type": "variables"
+  },
+  {
+    "text": "CTRA",
+    "type": "variables"
+  },
+  {
+    "text": "CTRB",
+    "type": "variables"
+  },
+  {
+    "text": "FRQA",
+    "type": "variables"
+  },
+  {
+    "text": "FRQB",
+    "type": "variables"
+  },
+  {
+    "text": "PHSA",
+    "type": "variables"
+  },
+  {
+    "text": "PHSB",
+    "type": "variables"
+  },
+  {
+    "text": "VCFG",
+    "type": "variables"
+  },
+  {
+    "text": "VSCL",
+    "type": "variables"
+  },
+  {
+    "text": "PAR",
+    "type": "variables"
+  },
+  {
+    "text": "SPR",
+    "type": "variables"
+  },
+  {
+    "text": "RESULT",
+    "type": "variables"
+  },
+  {
+    "text": "TRUE",
+    "type": "values"
+  },
+  {
+    "text": "FALSE",
+    "type": "values"
+  },
+  {
+    "text": "POSX",
+    "type": "values"
+  },
+  {
+    "text": "NEGX",
+    "type": "values"
+  },
+  {
+    "text": "PI",
+    "type": "values"
+  },
+  {
+    "text": "XTAL1",
+    "type": "values"
+  },
+  {
+    "text": "XTAL2",
+    "type": "values"
+  },
+  {
+    "text": "XTAL3",
+    "type": "values"
+  },
+  {
+    "text": "XINPUT",
+    "type": "values"
+  },
+  {
+    "text": "RCSLOW",
+    "type": "values"
+  },
+  {
+    "text": "RCFAST",
+    "type": "values"
+  },
+  {
+    "text": "PLL1X",
+    "type": "values"
+  },
+  {
+    "text": "PLL2X",
+    "type": "values"
+  },
+  {
+    "text": "PLL4X",
+    "type": "values"
+  },
+  {
+    "text": "PLL8X",
+    "type": "values"
+  },
+  {
+    "text": "PLL16X",
+    "type": "values"
+  },
+  {
+    "text": "_clkmode",
+    "type": "values"
+  },
+  {
+    "text": "_xinfreq",
+    "type": "values"
+  },
+  {
+    "text": "_clkfreq",
+    "type": "values"
+  },
+  {
+    "text": "ABS",
+    "type": "commands"
+  },
+  {
+    "text": "ABSNEG",
+    "type": "commands"
+  },
+  {
+    "text": "ADD",
+    "type": "commands"
+  },
+  {
+    "text": "ADDABS",
+    "type": "commands"
+  },
+  {
+    "text": "ADDS",
+    "type": "commands"
+  },
+  {
+    "text": "ADDSX",
+    "type": "commands"
+  },
+  {
+    "text": "ADDX",
+    "type": "commands"
+  },
+  {
+    "text": "ANDN",
+    "type": "commands"
+  },
+  {
+    "text": "CALL",
+    "type": "commands"
+  },
+  {
+    "text": "CMP",
+    "type": "commands"
+  },
+  {
+    "text": "CMPS",
+    "type": "commands"
+  },
+  {
+    "text": "CMPSUB",
+    "type": "commands"
+  },
+  {
+    "text": "CMPSX",
+    "type": "commands"
+  },
+  {
+    "text": "CMPX",
+    "type": "commands"
+  },
+  {
+    "text": "DJNZ",
+    "type": "commands"
+  },
+  {
+    "text": "HUBOP",
+    "type": "commands"
+  },
+  {
+    "text": "JMP",
+    "type": "commands"
+  },
+  {
+    "text": "JMPRET",
+    "type": "commands"
+  },
+  {
+    "text": "MAX",
+    "type": "commands"
+  },
+  {
+    "text": "MAXS",
+    "type": "commands"
+  },
+  {
+    "text": "MIN",
+    "type": "commands"
+  },
+  {
+    "text": "MINS",
+    "type": "commands"
+  },
+  {
+    "text": "MOV",
+    "type": "commands"
+  },
+  {
+    "text": "MOVD",
+    "type": "commands"
+  },
+  {
+    "text": "MOVI",
+    "type": "commands"
+  },
+  {
+    "text": "MOVS",
+    "type": "commands"
+  },
+  {
+    "text": "MUXC",
+    "type": "commands"
+  },
+  {
+    "text": "MUXNC",
+    "type": "commands"
+  },
+  {
+    "text": "MUXNZ",
+    "type": "commands"
+  },
+  {
+    "text": "MUXZ",
+    "type": "commands"
+  },
+  {
+    "text": "NEG",
+    "type": "commands"
+  },
+  {
+    "text": "NEGC",
+    "type": "commands"
+  },
+  {
+    "text": "NEGNC",
+    "type": "commands"
+  },
+  {
+    "text": "NEGNZ",
+    "type": "commands"
+  },
+  {
+    "text": "NEGZ",
+    "type": "commands"
+  },
+  {
+    "text": "NOP",
+    "type": "commands"
+  },
+  {
+    "text": "RCL",
+    "type": "commands"
+  },
+  {
+    "text": "RCR",
+    "type": "commands"
+  },
+  {
+    "text": "RDBYTE",
+    "type": "commands"
+  },
+  {
+    "text": "RDLONG",
+    "type": "commands"
+  },
+  {
+    "text": "RDWORD",
+    "type": "commands"
+  },
+  {
+    "text": "RET",
+    "type": "commands"
+  },
+  {
+    "text": "REV",
+    "type": "commands"
+  },
+  {
+    "text": "ROL",
+    "type": "commands"
+  },
+  {
+    "text": "ROR",
+    "type": "commands"
+  },
+  {
+    "text": "SAR",
+    "type": "commands"
+  },
+  {
+    "text": "SHL",
+    "type": "commands"
+  },
+  {
+    "text": "SHR",
+    "type": "commands"
+  },
+  {
+    "text": "SUB",
+    "type": "commands"
+  },
+  {
+    "text": "SUBABS",
+    "type": "commands"
+  },
+  {
+    "text": "SUBS",
+    "type": "commands"
+  },
+  {
+    "text": "SUBSX",
+    "type": "commands"
+  },
+  {
+    "text": "SUBX",
+    "type": "commands"
+  },
+  {
+    "text": "SUMC",
+    "type": "commands"
+  },
+  {
+    "text": "SUMNC",
+    "type": "commands"
+  },
+  {
+    "text": "SUMNZ",
+    "type": "commands"
+  },
+  {
+    "text": "SUMZ",
+    "type": "commands"
+  },
+  {
+    "text": "TEST",
+    "type": "commands"
+  },
+  {
+    "text": "TESTN",
+    "type": "commands"
+  },
+  {
+    "text": "TJNZ",
+    "type": "commands"
+  },
+  {
+    "text": "TJZ",
+    "type": "commands"
+  },
+  {
+    "text": "WRBYTE",
+    "type": "commands"
+  },
+  {
+    "text": "WRLONG",
+    "type": "commands"
+  },
+  {
+    "text": "WRWORD",
+    "type": "commands"
+  },
+  {
+    "text": "XOR",
+    "type": "commands"
+  },
+  {
+    "text": "IF_ALWAYS",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NEVER",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_E",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NE",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_A",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_B",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_AE",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_BE",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_EQ_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_EQ_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_NE_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_NE_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_AND_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_AND_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_AND_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_AND_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_AND_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_AND_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_AND_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_AND_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_OR_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_OR_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_C_OR_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_OR_C",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_OR_Z",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_Z_OR_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NC_OR_NZ",
+    "type": "attributes"
+  },
+  {
+    "text": "IF_NZ_OR_NC",
+    "type": "attributes"
+  },
+  {
+    "text": "WC",
+    "type": "attributes"
+  },
+  {
+    "text": "WZ",
+    "type": "attributes"
+  },
+  {
+    "text": "WR",
+    "type": "attributes"
+  },
+  {
+    "text": "NR",
+    "type": "attributes"
+  },
+  {
+    "text": "ANDC",
+    "type": "attributes"
+  },
+  {
+    "text": "ANDZ",
+    "type": "attributes"
+  },
+  {
+    "text": "ORC",
+    "type": "attributes"
+  },
+  {
+    "text": "ORZ",
+    "type": "attributes"
+  },
+  {
+    "text": "XORC",
+    "type": "attributes"
+  },
+  {
+    "text": "XORZ",
+    "type": "attributes"
+  },
+  {
+    "text": "ORG",
+    "type": "keywords"
+  },
+  {
+    "text": "FIT",
+    "type": "keywords"
+  },
+  {
+    "text": "RES",
+    "type": "keywords"
+  }
+]

--- a/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Edit.json
+++ b/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Edit.json
@@ -1,0 +1,36 @@
+{
+  "comment": {
+    "blocks": [
+      {
+        "begin": "{",
+        "end": "}",
+        "isNestable": true
+      }
+    ],
+    "inlines": [
+      {
+        "begin": "'"
+      }
+    ]
+  },
+  "stringDelimiters": [
+    {
+      "begin": "\"",
+      "end": "\""
+    }
+  ],
+  "indentation": {
+    "blockDelimiters": [
+      {
+        "begin": "repeat",
+        "end": "while",
+        "ignoreCase": true
+      },
+      {
+        "begin": "repeat",
+        "end": "until",
+        "ignoreCase": true
+      }
+    ]
+  }
+}

--- a/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Info.json
+++ b/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Info.json
@@ -1,0 +1,16 @@
+{
+  "fileMap": {
+    "extensions": [
+      "spin"
+    ]
+  },
+  "kind": "code",
+  "metadata": {
+    "author": "Phillip Stevens",
+    "description": "Parallax Propeller 1 (P8X32A) Spin with PASM in DAT. Not Spin2. Keywords from the Propeller Manual; opcodes from the P1 quick reference.",
+    "distributionURL": "https://coteditor.com",
+    "lastModified": "2026-09-10",
+    "license": "Same as CotEditor",
+    "version": "1.0.0"
+  }
+}

--- a/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Regex/Highlights.json
+++ b/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Regex/Highlights.json
@@ -1,0 +1,905 @@
+{
+  "keywords": [
+    {
+      "begin": "CON",
+      "ignoreCase": true
+    },
+    {
+      "begin": "VAR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OBJ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PUB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PRI",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DAT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IFNOT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ELSEIF",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ELSEIFNOT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ELSE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CASE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OTHER",
+      "ignoreCase": true
+    },
+    {
+      "begin": "REPEAT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WHILE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "UNTIL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FROM",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TO",
+      "ignoreCase": true
+    },
+    {
+      "begin": "STEP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEXT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "QUIT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RETURN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ABORT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "AND",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NOT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FILE",
+      "ignoreCase": true
+    }
+  ],
+  "commands": [
+    {
+      "begin": "STRSIZE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "STRCOMP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "STRING",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOOKUP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOOKUPZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOOKDOWN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOOKDOWNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CONSTANT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FLOAT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ROUND",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TRUNC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "BYTEFILL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WORDFILL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LONGFILL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "BYTEMOVE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WORDMOVE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LONGMOVE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "COGNEW",
+      "ignoreCase": true
+    },
+    {
+      "begin": "COGINIT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "COGSTOP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "COGID",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKNEW",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKRET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKSET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LOCKCLR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITCNT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITPEQ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITPNE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WAITVID",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CLKSET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "REBOOT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CHIPVER",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CLKFREQ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CLKMODE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ABS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ABSNEG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDABS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ADDX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "AND",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ANDN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CALL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPSUB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CMPX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DJNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "HUBOP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "JMP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "JMPRET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MAX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MAXS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MIN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MINS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOV",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOVD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOVI",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MOVS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXNC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "MUXZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGNC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NOP",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RDBYTE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RDLONG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RDWORD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RET",
+      "ignoreCase": true
+    },
+    {
+      "begin": "REV",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ROL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ROR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SAR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SHL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SHR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBABS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUBX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMNC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SUMZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TEST",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TESTN",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TJNZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "TJZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WRBYTE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WRLONG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WRWORD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XOR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ORG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FIT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RES",
+      "ignoreCase": true
+    }
+  ],
+  "types": [
+    {
+      "begin": "BYTE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WORD",
+      "ignoreCase": true
+    },
+    {
+      "begin": "LONG",
+      "ignoreCase": true
+    }
+  ],
+  "attributes": [
+    {
+      "begin": "IF_ALWAYS",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NEVER",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_E",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_A",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_B",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_AE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_BE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_EQ_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_EQ_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_NE_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_NE_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_AND_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_AND_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_AND_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_AND_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_AND_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_AND_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_AND_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_AND_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_OR_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_OR_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_C_OR_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_OR_C",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_OR_Z",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_Z_OR_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NC_OR_NZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "IF_NZ_OR_NC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "WR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ANDC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ANDZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ORC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "ORZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XORC",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XORZ",
+      "ignoreCase": true
+    },
+    {
+      "begin": ":[A-Za-z_][A-Za-z0-9_]*",
+      "regularExpression": true,
+      "description": "PASM local label"
+    },
+    {
+      "begin": "[A-Za-z_][A-Za-z0-9_]*#",
+      "regularExpression": true,
+      "description": "object constant"
+    }
+  ],
+  "variables": [
+    {
+      "begin": "INA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "INB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OUTA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "OUTB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DIRA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "DIRB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CNT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CTRA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "CTRB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FRQA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FRQB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PHSA",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PHSB",
+      "ignoreCase": true
+    },
+    {
+      "begin": "VCFG",
+      "ignoreCase": true
+    },
+    {
+      "begin": "VSCL",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PAR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "SPR",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RESULT",
+      "ignoreCase": true
+    }
+  ],
+  "values": [
+    {
+      "begin": "TRUE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "FALSE",
+      "ignoreCase": true
+    },
+    {
+      "begin": "POSX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "NEGX",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PI",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XTAL1",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XTAL2",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XTAL3",
+      "ignoreCase": true
+    },
+    {
+      "begin": "XINPUT",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCSLOW",
+      "ignoreCase": true
+    },
+    {
+      "begin": "RCFAST",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL1X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL2X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL4X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL8X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "PLL16X",
+      "ignoreCase": true
+    },
+    {
+      "begin": "_clkmode",
+      "ignoreCase": true
+    },
+    {
+      "begin": "_xinfreq",
+      "ignoreCase": true
+    },
+    {
+      "begin": "_clkfreq",
+      "ignoreCase": true
+    }
+  ],
+  "numbers": [
+    {
+      "begin": "%%[0-3][0-3_]*",
+      "regularExpression": true,
+      "description": "quaternary"
+    },
+    {
+      "begin": "%[01][01_]*",
+      "regularExpression": true,
+      "description": "binary"
+    },
+    {
+      "begin": "\\$[0-9A-Fa-f][0-9A-Fa-f_]*",
+      "regularExpression": true,
+      "description": "hex"
+    },
+    {
+      "begin": "\\b[0-9][0-9_]*\\b",
+      "regularExpression": true,
+      "description": "decimal"
+    }
+  ],
+  "characters": [
+    {
+      "begin": "#\"[^\"]\"",
+      "regularExpression": true,
+      "description": "character literal"
+    }
+  ]
+}

--- a/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Regex/Outlines.json
+++ b/CotEditor/Resources/Syntaxes/Spin.cotsyntax/Regex/Outlines.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "Block",
+    "ignoreCase": true,
+    "kind": "container",
+    "pattern": "^[\\t ]*(CON|VAR|OBJ|DAT)\\b",
+    "template": "$1"
+  },
+  {
+    "description": "Method",
+    "ignoreCase": true,
+    "kind": "function",
+    "pattern": "^[\\t ]*(PUB|PRI)[\\t ]+([A-Za-z_][A-Za-z0-9_]*)",
+    "template": "$1 $2"
+  }
+]


### PR DESCRIPTION
## Summary

Adds regex-based CotEditor 7 syntax packages for Parallax **Propeller 1 (P8X32A)** Spin and PASM.

- **Spin** (`.spin`): CON/VAR/OBJ/PUB/PRI/DAT, flow, builtins, and PASM in `DAT`.
- **PASM** (`.pasm`): P1 opcodes, conditions (`IF_Z`, …), effects (`WC` `WZ` `WR` `NR`), `ORG`/`FIT`/`RES`.

This is not Spin2 or PASM2. `.spin2` is not mapped.

Highlighting follows the Propeller Manual / Quick Reference and [bitbased/sublime-spintools](https://github.com/bitbased/sublime-spintools) for comments (`'` and nested `{ }`), strings (`"`), and `$` / `%` / `%%` numbers.

Per CONTRIBUTING, Propeller Spin is a smaller language. If you would rather keep these as additional styles, the same packages are published at https://github.com/feilipu/coteditor-spin-pasm for the [Additional Syntax Styles](https://github.com/coteditor/CotEditor/wiki/Additional-Syntax-Styles) wiki. License on the bundled copies is “Same as CotEditor”.

## Test plan

- [ ] Import or build with these packages on CotEditor 7.
- [ ] Open a `.spin` file that contains a `DAT` PASM block (for example an ACIA driver) and check block names, `' comments`, `{ }` docs, `$hex` / `%bin`, and opcodes such as `waitpeq` / `if_z`.
- [ ] Open a `.pasm` fragment and check `org` / `fit` / `res` and condition prefixes.
- [ ] Confirm `.asm` / `.s` still use the existing Assembly (NASM) style.